### PR TITLE
directory seperator fix

### DIFF
--- a/src/Commands/Concerns/CanManipulateFiles.php
+++ b/src/Commands/Concerns/CanManipulateFiles.php
@@ -52,7 +52,7 @@ trait CanManipulateFiles
 
         $filesystem->ensureDirectoryExists(
             (string) Str::of($path)
-                ->beforeLast('/'),
+                ->beforeLast(DIRECTORY_SEPARATOR),
         );
 
         $filesystem->put($path, $contents);


### PR DESCRIPTION
Using "/" as directory separator throws "mkdir(): File exists error" on Windows so it should be replaced with DIRECTORY_SEPARATOR constant.