### PR TITLE
Addition of "Navigation Group" setting.

### DIFF
--- a/stubs/Config.stub
+++ b/stubs/Config.stub
@@ -25,6 +25,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Navigation Group
+    |--------------------------------------------------------------------------
+    |
+    | Change this setting to correspond with the desired navigation group. Default is "Filament Shield" which is derived from the included translations.
+    | 
+    */
+
+    'navgroup' => [
+        'enabled' => {{ navgroup_enabled }},
+        'name' => '{{ navgroup_name }}',
+        
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Prefixes
     |--------------------------------------------------------------------------
     |

--- a/stubs/resources/RoleResource.php
+++ b/stubs/resources/RoleResource.php
@@ -184,7 +184,7 @@ class RoleResource extends Resource
 
     protected static function getNavigationGroup(): ?string
     {
-        return __('filament-shield::filament-shield.nav.group');
+        return (config('filament-shield.navgroup.enabled') === TRUE) ? config('filament-shield.navgroup.name') : __('filament-shield::filament-shield.nav.group');
     }
 
     protected static function getNavigationLabel(): string

--- a/stubs/resources/RoleResource/Pages/ShieldSettings.php
+++ b/stubs/resources/RoleResource/Pages/ShieldSettings.php
@@ -49,6 +49,8 @@ class ShieldSettings extends Page implements HasFormActions
             'exclude_widgets' => config('filament-shield.exclude.widgets'),
             'exclude_resources' => config('filament-shield.exclude.resources'),
             'register_role_policy' => config('filament-shield.register_role_policy'),
+            'navgroup_enabled' => config('filament-shield.navgroup.enabled'),
+            'navgroup_name' => config('filament-shield.navgroup.name'),
         ]);
     }
 
@@ -112,6 +114,34 @@ class ShieldSettings extends Page implements HasFormActions
                     'md' => 2,
                     'lg' => 3
                 ]),
+
+
+                $layout::make()
+                ->schema([
+                Forms\Components\Grid::make()
+                    ->schema([
+                        Forms\Components\Placeholder::make('Custom Navigation Group')
+                            ->label(__('filament-shield::filament-shield.labels.navgroup.placeholder'))
+                            ->content(__('filament-shield::filament-shield.labels.navgroup.message'))
+                            ->extraAttributes(['class' => 'text-sm text-gray-500']),
+                        Forms\Components\Toggle::make('navgroup_enabled')
+                            ->label(fn($state): string => $state ? __("filament-shield::filament-shield.labels.status.enabled") : __("filament-shield::filament-shield.labels.status.disabled"))
+                            ->default(config('filament-shield.navgroup.enabled'))
+                            ->reactive(),
+                        Forms\Components\Grid::make()
+                            ->visible(fn($get) => $get('navgroup_enabled'))
+                            ->schema([
+                                Forms\Components\TextInput::make('navgroup_name')
+                                ->label(__('filament-shield::filament-shield.labels.navgroup.name'))
+                                ->required(),
+                            ])
+                            ->columns(1)
+                    ])
+            ]),
+
+
+            
+                                        
             $layout::make()
             ->schema([
                     Forms\Components\Placeholder::make('')
@@ -262,6 +292,8 @@ class ShieldSettings extends Page implements HasFormActions
                 'exclude_pages' => json_encode($this->exclude_pages),
                 'exclude_widgets' => json_encode($this->exclude_widgets),
                 'exclude_resources' => json_encode($this->exclude_resources),
+                'navgroup_enabled' => $this->navgroup_enabled ? 'true' : 'false',
+                'navgroup_name' => $this->navgroup_name,
             ]
         );
     }


### PR DESCRIPTION
This setting can be changed via the GUI based settings, and/or, the configuration file.

Setting, if enabled, will allow someone to dynamically change the navigation group. If left disabled, it will automatically revert to the default functionality of drawing the navigation group name from the translation files.