### PR TITLE
Fix: hardcodeded user model in policy generator

### DIFF
--- a/src/Commands/Concerns/CanGeneratePolicy.php
+++ b/src/Commands/Concerns/CanGeneratePolicy.php
@@ -37,9 +37,8 @@ trait CanGeneratePolicy
                 return $gates;
             }, []);
         
-        $configPath = ('auth.providers.' . config('auth.guards.' . config('filament.auth.guard') . '.provider') . '.model');
 
-        $defaultPermissions['guardNamespace'] = config($configPath);
+        $defaultPermissions['guardNamespace'] = auth(config('filament.auth.guard'))->getProvider()->getModel();
         $defaultPermissions['guardModel']     = Str::of($defaultPermissions['guardNamespace'])->afterLast('\\');
         
         $defaultPermissions['modelPolicy'] = "{$model}Policy";

--- a/src/Commands/Concerns/CanGeneratePolicy.php
+++ b/src/Commands/Concerns/CanGeneratePolicy.php
@@ -36,7 +36,12 @@ trait CanGeneratePolicy
 
                 return $gates;
             }, []);
+        
+        $configPath = ('auth.providers.' . config('auth.guards.' . config('filament.auth.guard') . '.provider') . '.model');
 
+        $defaultPermissions['guardNamespace'] = config($configPath);
+        $defaultPermissions['guardModel']     = Str::of($defaultPermissions['guardNamespace'])->afterLast('\\');
+        
         $defaultPermissions['modelPolicy'] = "{$model}Policy";
 
         return $defaultPermissions;

--- a/stubs/DefaultPolicy.stub
+++ b/stubs/DefaultPolicy.stub
@@ -2,7 +2,7 @@
 
 namespace App\Policies;
 
-use App\Models\User;
+use {{ guardNamespace }};
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class {{ modelPolicy }}
@@ -12,10 +12,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can view any models.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function viewAny(User $user)
+    public function viewAny({{ guardModel }} $user)
     {
         return $user->can('{{ ViewAny }}');
     }
@@ -23,10 +23,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can view the model.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function view(User $user)
+    public function view({{ guardModel }} $user)
     {
         return $user->can('{{ View }}');
     }
@@ -34,10 +34,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can create models.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function create(User $user)
+    public function create({{ guardModel }} $user)
     {
         return $user->can('{{ Create }}');
     }
@@ -45,10 +45,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can update the model.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function update(User $user)
+    public function update({{ guardModel }} $user)
     {
         return $user->can('{{ Update }}');
     }
@@ -56,10 +56,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can delete the model.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function delete(User $user)
+    public function delete({{ guardModel }} $user)
     {
         return $user->can('{{ Delete }}');
     }
@@ -67,10 +67,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can bulk delete.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function deleteAny(User $user)
+    public function deleteAny({{ guardModel }} $user)
     {
         return $user->can('{{ DeleteAny }}');
     }

--- a/stubs/UserPolicy.stub
+++ b/stubs/UserPolicy.stub
@@ -2,7 +2,7 @@
 
 namespace App\Policies;
 
-use App\Models\User;
+use {{ guardNamespace }};
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class {{ modelPolicy }}
@@ -12,10 +12,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can view any models.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function viewAny(User $user)
+    public function viewAny({{ guardModel }} $user)
     {
         return $user->can('{{ ViewAny }}');
     }
@@ -23,10 +23,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can view the model.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function view(User $user)
+    public function view({{ guardModel }} $user)
     {
         return $user->can('{{ View }}');
     }
@@ -34,10 +34,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can create models.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function create(User $user)
+    public function create({{ guardModel }} $user)
     {
         return $user->can('{{ Create }}');
     }
@@ -45,10 +45,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can update the model.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function update(User $user)
+    public function update({{ guardModel }} $user)
     {
         return $user->can('{{ Update }}');
     }
@@ -56,10 +56,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can delete the model.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function delete(User $user)
+    public function delete({{ guardModel }} $user)
     {
         return $user->can('{{ Delete }}');
     }
@@ -67,10 +67,10 @@ class {{ modelPolicy }}
     /**
      * Determine whether the user can bulk delete.
      *
-     * @param  \App\Models\User  $user
+     * @param  \{{ guardNamespace }}  $user
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function deleteAny(User $user)
+    public function deleteAny({{ guardModel }} $user)
     {
         return $user->can('{{ DeleteAny }}');
     }


### PR DESCRIPTION
Change hardcoded `App\Models\Users` in policies stubs  to the default `auth guard` model from filament config file