### PR TITLE
Allow user option for shield:super-admin command

### DIFF
--- a/src/Commands/MakeShieldSuperAdminCommand.php
+++ b/src/Commands/MakeShieldSuperAdminCommand.php
@@ -12,7 +12,8 @@ class MakeShieldSuperAdminCommand extends Command
 {
     use CanValidateInput;
 
-    public $signature = 'shield:super-admin';
+    public $signature = 'shield:super-admin
+        {--user= : ID of user to be made super admin.}';
 
     public $description = 'Creates Filament Super Admin';
 
@@ -38,7 +39,15 @@ class MakeShieldSuperAdminCommand extends Command
             ]);
         }
 
-        if ($userProvider->getModel()::count() === 1) {
+        if ($this->option('user')) {
+            $superAdmin = $userProvider->getModel()::findOrFail($this->option('user'));
+
+            $superAdmin->assignRole(config('filament-shield.super_admin.name'));
+
+            if (config('filament-shield.filament_user.enabled')) {
+                $superAdmin->assignRole(config('filament-shield.filament_user.name'));
+            }
+        } elseif ($userProvider->getModel()::count() === 1) {
             $superAdmin = $userProvider->getModel()::first();
 
             $superAdmin->assignRole(config('filament-shield.super_admin.name'));


### PR DESCRIPTION
This allows you to provide a `user` argument to the `shield:super-admin` command to skip the interactive portion. This is entirely optional but can be used like so:

```
php artisan shield:super-admin --user=1
```