### PR TITLE
Add config setting to show/hide navigation badge

### DIFF
--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -4,6 +4,7 @@ return [
     'shield_resource' => [
         'slug' => 'shield/roles',
         'navigation_sort' => -1,
+        'show_navigation_badge' => true,
     ],
 
     'auth_provider_model' => [

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -206,7 +206,9 @@ class RoleResource extends Resource
 
     protected static function getNavigationBadge(): ?string
     {
-        return static::$model::count();
+        return config('filament-shield.shield_resource.show_navigation_badge', true)
+            ? static::$model::count()
+            : null;
     }
 
     /**--------------------------------*


### PR DESCRIPTION
Fairly self-explanatory, but this PR adds a config setting to allow the user to show or hide the navigation badge for the Role Resource. In my case, the badge doesn't fit with the rest of my navigation so I'd like to be able to hide it.