### PR TITLE
Config option to easily turn off navigation group

### DIFF
--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -4,21 +4,22 @@ return [
     'shield_resource' => [
         'slug' => 'shield/roles',
         'navigation_sort' => -1,
-        'navigation_badge' => true
+        'navigation_badge' => true,
+        'navigation_group' => true,
     ],
 
     'auth_provider_model' => [
-        'fqcn' => 'App\\Models\\User'
+        'fqcn' => 'App\\Models\\User',
     ],
 
     'super_admin' => [
         'enabled' => true,
-        'name'  => 'super_admin'
+        'name'  => 'super_admin',
     ],
 
     'filament_user' => [
         'enabled' => true,
-        'name' => 'filament_user'
+        'name' => 'filament_user',
     ],
 
     'permission_prefixes' => [
@@ -49,7 +50,7 @@ return [
     ],
 
     'generator' => [
-        'option' => 'policies_and_permissions'
+        'option' => 'policies_and_permissions',
     ],
 
     'exclude' => [
@@ -67,6 +68,6 @@ return [
     ],
 
     'register_role_policy' => [
-        'enabled' => false
+        'enabled' => false,
     ],
 ];

--- a/src/Commands/MakeShieldDoctorCommand.php
+++ b/src/Commands/MakeShieldDoctorCommand.php
@@ -21,6 +21,7 @@ class MakeShieldDoctorCommand extends Command
                 'Resource Slug' => Utils::getResourceSlug(),
                 'Resource Sort' => Utils::getResourceNavigationSort(),
                 'Resource Badge' => Utils::isResourceNavigationBadgeEnabled() ? '<fg=green;options=bold>ENABLED</>' : '<fg=red;options=bold>DISABLED</>',
+                'Resource Group' => Utils::isResourceNavigationGroupEnabled() ? '<fg=green;options=bold>ENABLED</>' : '<fg=red;options=bold>DISABLED</>',
                 'Translations' => is_dir(resource_path('resource/lang/vendor/filament-shield')) ? '<fg=red;options=bold>PUBLISHED</>' : '<fg=green;options=bold>NOT PUBLISHED</>',
                 'Version' => InstalledVersions::getPrettyVersion('bezhansalleh/filament-shield'),
                 'Views' => is_dir(resource_path('views/vendor/filament-shield')) ? '<fg=red;options=bold>PUBLISHED</>' : '<fg=green;options=bold>NOT PUBLISHED</>',

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -182,7 +182,9 @@ class RoleResource extends Resource
 
     protected static function getNavigationGroup(): ?string
     {
-        return __('filament-shield::filament-shield.nav.group');
+        return Utils::isResourceNavigationGroupEnabled()
+            ? __('filament-shield::filament-shield.nav.group')
+            : '';
     }
 
     protected static function getNavigationLabel(): string

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -19,6 +19,11 @@ class Utils
         return config('filament-shield.shield_resource.navigation_badge', true);
     }
 
+    public static function isResourceNavigationGroupEnabled(): bool
+    {
+        return config('filament-shield.shield_resource.navigation_group', true);
+    }
+
     public static function getAuthProviderFQCN()
     {
         return config('filament-shield.auth_provider_model.fqcn');


### PR DESCRIPTION
This PR adds a config option which allows the user to quickly and easily turn off the navigation group (slotting the navigation item for Shield in with the rest of the navigation items). The new section of the config looks like this:

```
    'shield_resource' => [
        'slug' => 'shield/roles',
        'navigation_sort' => -1,
        'navigation_badge' => true,
        'navigation_group' => true,
    ],
```