### PR TITLE
Added ability to create resource-specific permissions

### DIFF
--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -45,6 +45,12 @@ return [
         'widget' => 'widget',
     ],
 
+    'custom_permissions' => [
+		'resources' => [
+
+		],
+	],
+
     'entities' => [
         'pages' => true,
         'widgets' => true,

--- a/src/Commands/Concerns/CanGeneratePolicy.php
+++ b/src/Commands/Concerns/CanGeneratePolicy.php
@@ -44,6 +44,7 @@ trait CanGeneratePolicy
     protected function generatePolicyStubVariables(array $entity): array
     {
         $stubVariables = collect(Utils::getGeneralResourcePermissionPrefixes())
+            ->merge(Utils::getSpecificResourcePermissionPrefixes($entity['resource']))
             ->reduce(function ($gates, $permission) use ($entity) {
                 $gates[Str::studly($permission)] = $permission.'_'.$entity['resource'];
 

--- a/src/Commands/Concerns/CanGeneratePolicy.php
+++ b/src/Commands/Concerns/CanGeneratePolicy.php
@@ -44,7 +44,6 @@ trait CanGeneratePolicy
     protected function generatePolicyStubVariables(array $entity): array
     {
         $stubVariables = collect(Utils::getGeneralResourcePermissionPrefixes())
-            ->merge(Utils::getSpecificResourcePermissionPrefixes($entity['resource']))
             ->reduce(function ($gates, $permission) use ($entity) {
                 $gates[Str::studly($permission)] = $permission.'_'.$entity['resource'];
 

--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -18,6 +18,7 @@ class FilamentShield
         if (Utils::isResourceEntityEnabled()) {
             $permissions = collect();
             collect(Utils::getGeneralResourcePermissionPrefixes())
+                ->merge(Utils::getSpecificResourcePermissionPrefixes($resource))
                 ->each(function ($prefix) use ($resource, $permissions) {
                     $permissions->push(Permission::firstOrCreate(
                         ['name' => $prefix.'_'.$resource],

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -386,7 +386,7 @@ class RoleResource extends Resource
             })->map->count()
             ->reduce(function ($counts, $role, $key) use ($entity) {
                 $permissions_count = collect(Utils::getGeneralResourcePermissionPrefixes())
-                    ->merge(Utils::getSpecificResourcePermissionPrefixes($entity['resource']))
+                    ->merge(Utils::getSpecificResourcePermissionPrefixes($entity))
                     ->count();
                 if ($role > 1 && $role == $permissions_count) {
                     $counts[$key] = true;

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -358,7 +358,7 @@ class RoleResource extends Resource
     protected static function refreshResourceEntityStateAfterUpdate(Closure $set, Closure $get, string $entity): void
     {
         $permissionStates = collect(Utils::getGeneralResourcePermissionPrefixes())
-            ->merge(Utils::getSpecificResourcePermissionPrefixes($entity['resource']))
+            ->merge(Utils::getSpecificResourcePermissionPrefixes($entity))
             ->map(function ($permission) use ($get, $entity) {
                 return (bool) $get($permission.'_'.$entity);
             });

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -265,7 +265,7 @@ class RoleResource extends Resource
 
     public static function getResourceEntityPermissionsSchema($entity): ?array
     {
-        return collect(Utils::getGeneralResourcePermissionPrefixes())->reduce(function ($permissions /** @phpstan ignore-line */, $permission) use ($entity) {
+        return collect(Utils::getGeneralResourcePermissionPrefixes())->merge(Utils::getSpecificResourcePermissionPrefixes($entity['resource']))->reduce(function ($permissions /** @phpstan ignore-line */, $permission) use ($entity) {
             $permissions[] = Forms\Components\Checkbox::make($permission.'_'.$entity['resource'])
                 ->label(FilamentShield::getLocalizedResourcePermissionLabel($permission))
                 ->extraAttributes(['class' => 'text-primary-600'])
@@ -485,7 +485,7 @@ class RoleResource extends Resource
     {
         $resourcePermissions = collect();
         collect(FilamentShield::getResources())->each(function ($entity) use ($resourcePermissions) {
-            collect(Utils::getGeneralResourcePermissionPrefixes())->map(function ($permission) use ($resourcePermissions, $entity) {
+            collect(Utils::getGeneralResourcePermissionPrefixes())->merge(Utils::getSpecificResourcePermissionPrefixes($entity['resource']))->map(function ($permission) use ($resourcePermissions, $entity) {
                 $resourcePermissions->push((string) Str::of($permission.'_'.$entity['resource']));
             });
         });

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -80,6 +80,11 @@ class Utils
         return config('filament-shield.permission_prefixes.resource');
     }
 
+    public static function getSpecificResourcePermissionPrefixes(string $resource_suffix): array
+	{
+		return config('filament-shield.custom_permissions.resources.' . $resource_suffix, []);
+	}
+
     public static function getPagePermissionPrefix(): string
     {
         return (string) config('filament-shield.permission_prefixes.page');


### PR DESCRIPTION
this is an example config to generate the permissions

```php
'custom_permissions' => [
		'resources' => [
			'certified::diamond' => [
				'view_warehouse',
				'view_administration',
				'view_sell',
				'view_buy',
				'view_characteristics',
			],
		],
	],
```
![Schermata 2022-09-29 alle 10 46 41](https://user-images.githubusercontent.com/875086/192985345-a81c5eb7-0300-4fc5-8323-9b141e53b011.jpg)

policy methods should be created manually

```php
public function view_warehouse(User $user, CertifiedDiamond $certifiedDiamond)
	{
		return $user->can('view_warehouse_certified::diamond');
	}
```

