### PR TITLE
introduced ability to override used Role and Permission Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `filament-shield` will be documented in this file.
 
+## 2.2.8 - 2022-10-10
+
+- introduced ability to override used Role and Permission Model in RoleResource in https://github.com/bezhanSalleh/filament-shield/pull/133
+
 ## 2.2.7 - 2022-09-29
 
 ### What's Changed

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -56,6 +56,11 @@ return [
         'option' => 'policies_and_permissions',
     ],
 
+    'models' =>  [
+        'role' => \Spatie\Permission\Models\Role::class,
+        'permission' => \Spatie\Permission\Models\Permission::class,
+    ],
+
     'exclude' => [
         'enabled' => true,
 

--- a/src/Commands/MakeShieldSuperAdminCommand.php
+++ b/src/Commands/MakeShieldSuperAdminCommand.php
@@ -8,14 +8,12 @@ use BezhanSalleh\FilamentShield\Support\Utils;
 use Filament\Facades\Filament;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
-use Spatie\Permission\Models\Role;
 
 class MakeShieldSuperAdminCommand extends Command
 {
     use CanValidateInput;
 
-    public $signature = 'shield:super-admin
-        {--user= : ID of user to be made super admin.}';
+    public $signature = 'shield:super-admin {--user= : ID of user to be made super admin.}';
 
     public $description = 'Creates Filament Super Admin';
 
@@ -29,11 +27,13 @@ class MakeShieldSuperAdminCommand extends Command
         /** @var EloquentUserProvider $userProvider */
         $userProvider = $auth->getProvider();
 
-        if (Role::whereName(Utils::getSuperAdminName())->doesntExist()) {
+        $roleModel = Utils::getRoleModel();
+
+        if ((new $roleModel())::whereName(Utils::getSuperAdminName())->doesntExist()) {
             FilamentShield::createRole();
         }
 
-        if (Utils::isFilamentUserRoleEnabled() && Role::whereName(Utils::getFilamentUserRoleName())->doesntExist()) {
+        if (Utils::isFilamentUserRoleEnabled() && (new $roleModel())::whereName(Utils::getFilamentUserRoleName())->doesntExist()) {
             FilamentShield::createRole(isSuperAdmin: false);
         }
 

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -24,6 +24,11 @@ class RoleResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'name';
 
+    public function __construct()
+    {
+        static::$model = Utils::getRoleModel();
+    }
+
     public static function form(Form $form): Form
     {
         return $form
@@ -495,7 +500,9 @@ class RoleResource extends Resource
             ->merge(FilamentShield::getWidgets())
             ->values();
 
-        return Permission::whereNotIn('name', $entitiesPermissions)->pluck('name');
+        $permissionModel = Utils::getPermissionModel();
+
+        return (new $permissionModel())::whereNotIn('name', $entitiesPermissions)->pluck('name');
     }
 
     protected static function getCustomEntitiesPermisssionSchema(): ?array

--- a/src/Resources/RoleResource/Pages/CreateRole.php
+++ b/src/Resources/RoleResource/Pages/CreateRole.php
@@ -3,6 +3,7 @@
 namespace BezhanSalleh\FilamentShield\Resources\RoleResource\Pages;
 
 use BezhanSalleh\FilamentShield\Resources\RoleResource;
+use BezhanSalleh\FilamentShield\Support\Utils;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -26,9 +27,10 @@ class CreateRole extends CreateRecord
 
     protected function afterCreate(): void
     {
+	$permissionModel = Utils::getPermissionModel();
         $permissionModels = collect();
-        $this->permissions->each(function ($permission) use ($permissionModels) {
-            $permissionModels->push(Permission::firstOrCreate(
+        $this->permissions->each(function ($permission) use ($permissionModel, $permissionModels) {
+            $permissionModels->push((new $permissionModel())::firstOrCreate(
                 /** @phpstan-ignore-next-line */
                 ['name' => $permission],
                 ['guard_name' => $this->data['guard_name']]

--- a/src/Resources/RoleResource/Pages/EditRole.php
+++ b/src/Resources/RoleResource/Pages/EditRole.php
@@ -3,6 +3,7 @@
 namespace BezhanSalleh\FilamentShield\Resources\RoleResource\Pages;
 
 use BezhanSalleh\FilamentShield\Resources\RoleResource;
+use BezhanSalleh\FilamentShield\Support\Utils;
 use Filament\Pages\Actions;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Arr;
@@ -34,9 +35,10 @@ class EditRole extends EditRecord
 
     protected function afterSave(): void
     {
+	$permissionModel = Utils::getPermissionModel();
         $permissionModels = collect();
-        $this->permissions->each(function ($permission) use ($permissionModels) {
-            $permissionModels->push(Permission::firstOrCreate(
+        $this->permissions->each(function ($permission) use ($permissionModel, $permissionModels) {
+            $permissionModels->push((new $permissionModel())::firstOrCreate(
                 ['name' => $permission],
                 ['guard_name' => $this->data['guard_name']]
             ));

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -4,6 +4,16 @@ namespace BezhanSalleh\FilamentShield\Support;
 
 class Utils
 {
+    public static function getRoleModel(): string
+    {
+        return (string) config('filament-shield.models.role') ?? Spatie\Permission\Models\Role::class;
+    }
+
+    public static function getPermissionModel(): string
+    {
+        return (string) config('filament-shield.models.permission') ?? Spatie\Permission\Models\Permission::class;
+    }
+
     public static function getFilamentAuthGuard(): string
     {
         return (string) config('filament.auth.guard');


### PR DESCRIPTION
introduced ability to override used Role and Permission Model in Role Resource.

useful if, for example, your `roles` and `permissions` table is not on the default database connection.