### PR TITLE
feat: use config models

### DIFF
--- a/src/Commands/MakeShieldSeederCommand.php
+++ b/src/Commands/MakeShieldSeederCommand.php
@@ -2,9 +2,8 @@
 
 namespace BezhanSalleh\FilamentShield\Commands;
 
+use BezhanSalleh\FilamentShield\FilamentShield;
 use Illuminate\Console\Command;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'shield:seeder')]
@@ -43,7 +42,7 @@ class MakeShieldSeederCommand extends Command
             ]);
         }
 
-        if (Role::doesntExist() && Permission::doesntExist()) {
+        if (FilamentShield::getRoleModel()::doesntExist() && FilamentShield::getPermissionModel()::doesntExist()) {
             $this->warn(' There are no roles or permissions to create the seeder. Please first run `shield:generate --all`');
 
             return static::INVALID;
@@ -53,8 +52,8 @@ class MakeShieldSeederCommand extends Command
         $permissionsViaRoles = collect();
         $directPermissions = collect();
 
-        if (Role::exists()) {
-            $permissionsViaRoles = collect(Role::with('permissions')->get())
+        if (FilamentShield::getRoleModel()::exists()) {
+            $permissionsViaRoles = collect(FilamentShield::getRoleModel()::with('permissions')->get())
                 ->map(function ($role) use ($directPermissionNames) {
                     $rolePermissions = $role->permissions
                         ->pluck('name')
@@ -70,8 +69,8 @@ class MakeShieldSeederCommand extends Command
                 });
         }
 
-        if (Permission::exists()) {
-            $directPermissions = collect(Permission::get())
+        if (FilamentShield::getPermissionModel()::exists()) {
+            $directPermissions = collect(FilamentShield::getPermissionModel()::get())
                 ->filter(fn ($permission) => ! in_array($permission->name, $directPermissionNames->unique()->flatten()->all()))
                 ->map(fn ($permission) => [
                     'name' => $permission->name,

--- a/src/Commands/MakeShieldSuperAdminCommand.php
+++ b/src/Commands/MakeShieldSuperAdminCommand.php
@@ -8,7 +8,6 @@ use BezhanSalleh\FilamentShield\Support\Utils;
 use Filament\Facades\Filament;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
-use Spatie\Permission\Models\Role;
 
 class MakeShieldSuperAdminCommand extends Command
 {
@@ -29,11 +28,11 @@ class MakeShieldSuperAdminCommand extends Command
         /** @var EloquentUserProvider $userProvider */
         $userProvider = $auth->getProvider();
 
-        if (Role::whereName(Utils::getSuperAdminName())->doesntExist()) {
+        if (FilamentShield::getRoleModel()::whereName(Utils::getSuperAdminName())->doesntExist()) {
             FilamentShield::createRole();
         }
 
-        if (Utils::isFilamentUserRoleEnabled() && Role::whereName(Utils::getFilamentUserRoleName())->doesntExist()) {
+        if (Utils::isFilamentUserRoleEnabled() && FilamentShield::getRoleModel()::whereName(Utils::getFilamentUserRoleName())->doesntExist()) {
             FilamentShield::createRole(isSuperAdmin: false);
         }
 

--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -7,19 +7,27 @@ use Filament\Facades\Filament;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 use Spatie\Permission\PermissionRegistrar;
 
 class FilamentShield
 {
+    public static function getRoleModel(): string
+    {
+        return config('permission.models.role');
+    }
+
+    public static function getPermissionModel(): string
+    {
+        return config('permission.models.permission');
+    }
+
     public static function generateForResource(string $resource): void
     {
         if (Utils::isResourceEntityEnabled()) {
             $permissions = collect();
             collect(Utils::getGeneralResourcePermissionPrefixes())
                 ->each(function ($prefix) use ($resource, $permissions) {
-                    $permissions->push(Permission::firstOrCreate(
+                    $permissions->push(static::getPermissionModel()::firstOrCreate(
                         ['name' => $prefix.'_'.$resource],
                         ['guard_name' => Utils::getFilamentAuthGuard()]
                     ));
@@ -32,7 +40,7 @@ class FilamentShield
     public static function generateForPage(string $page): void
     {
         if (Utils::isPageEntityEnabled()) {
-            $permission = Permission::firstOrCreate(
+            $permission = static::getPermissionModel()::firstOrCreate(
                 ['name' => $page],
                 ['guard_name' => Utils::getFilamentAuthGuard()]
             )->name;
@@ -44,7 +52,7 @@ class FilamentShield
     public static function generateForWidget(string $widget): void
     {
         if (Utils::isWidgetEntityEnabled()) {
-            $permission = Permission::firstOrCreate(
+            $permission = static::getPermissionModel()::firstOrCreate(
                 ['name' => $widget],
                 ['guard_name' => Utils::getFilamentAuthGuard()]
             )->name;
@@ -64,9 +72,9 @@ class FilamentShield
         }
     }
 
-    public static function createRole(bool $isSuperAdmin = true): Role
+    public static function createRole(bool $isSuperAdmin = true)
     {
-        return Role::firstOrCreate(
+        return static::getRoleModel()::firstOrCreate(
             ['name' => $isSuperAdmin ? Utils::getSuperAdminName() : Utils::getFilamentUserRoleName()],
             ['guard_name' => $isSuperAdmin ? Utils::getFilamentAuthGuard() : Utils::getFilamentAuthGuard()]
         );

--- a/src/FilamentShieldServiceProvider.php
+++ b/src/FilamentShieldServiceProvider.php
@@ -38,7 +38,7 @@ class FilamentShieldServiceProvider extends PluginServiceProvider
         }
 
         if (Utils::isRolePolicyRegistered()) {
-            Gate::policy('Spatie\Permission\Models\Role', 'App\Policies\RolePolicy');
+            Gate::policy(FilamentShield::getRoleModel(), 'App\Policies\RolePolicy');
         }
     }
 

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -15,13 +15,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 class RoleResource extends Resource
 {
-    protected static ?string $model = Role::class;
-
     protected static ?string $recordTitleAttribute = 'name';
 
     protected static $permissionsCollection;
@@ -171,6 +167,11 @@ class RoleResource extends Resource
         ];
     }
 
+    public static function getModel(): string
+    {
+        return FilamentShield::getRoleModel();
+    }
+
     public static function getModelLabel(): string
     {
         return __('filament-shield::filament-shield.resource.label.role');
@@ -211,7 +212,7 @@ class RoleResource extends Resource
     protected static function getNavigationBadge(): ?string
     {
         return Utils::isResourceNavigationBadgeEnabled()
-            ? static::$model::count()
+            ? static::getModel()::count()
             : null;
     }
 
@@ -227,7 +228,7 @@ class RoleResource extends Resource
     public static function getResourceEntitiesSchema(): ?array
     {
         if (blank(static::$permissionsCollection)) {
-            static::$permissionsCollection = Permission::all();
+            static::$permissionsCollection = FilamentShield::getPermissionModel()::all();
         }
 
         return collect(FilamentShield::getResources())->sortKeys()->reduce(function ($entities, $entity) {

--- a/src/Resources/RoleResource/Pages/CreateRole.php
+++ b/src/Resources/RoleResource/Pages/CreateRole.php
@@ -2,12 +2,12 @@
 
 namespace BezhanSalleh\FilamentShield\Resources\RoleResource\Pages;
 
+use BezhanSalleh\FilamentShield\FilamentShield;
 use BezhanSalleh\FilamentShield\Resources\RoleResource;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Spatie\Permission\Models\Permission;
 
 class CreateRole extends CreateRecord
 {
@@ -28,7 +28,7 @@ class CreateRole extends CreateRecord
     {
         $permissionModels = collect();
         $this->permissions->each(function ($permission) use ($permissionModels) {
-            $permissionModels->push(Permission::firstOrCreate(
+            $permissionModels->push(FilamentShield::getPermissionModel()::firstOrCreate(
                 /** @phpstan-ignore-next-line */
                 ['name' => $permission],
                 ['guard_name' => $this->data['guard_name']]

--- a/src/Resources/RoleResource/Pages/EditRole.php
+++ b/src/Resources/RoleResource/Pages/EditRole.php
@@ -2,13 +2,13 @@
 
 namespace BezhanSalleh\FilamentShield\Resources\RoleResource\Pages;
 
+use BezhanSalleh\FilamentShield\FilamentShield;
 use BezhanSalleh\FilamentShield\Resources\RoleResource;
 use Filament\Pages\Actions;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Spatie\Permission\Models\Permission;
 
 class EditRole extends EditRecord
 {
@@ -36,7 +36,7 @@ class EditRole extends EditRecord
     {
         $permissionModels = collect();
         $this->permissions->each(function ($permission) use ($permissionModels) {
-            $permissionModels->push(Permission::firstOrCreate(
+            $permissionModels->push(FilamentShield::getPermissionModel()::firstOrCreate(
                 ['name' => $permission],
                 ['guard_name' => $this->data['guard_name']]
             ));


### PR DESCRIPTION
When extend role or permission model, we should use the model specified in the config so that we do not get errors in filament dashboard or commands.

Example extend, uuid based role and permission https://spatie.be/docs/laravel-permission/v5/advanced-usage/uuid