### PR TITLE
Customize resource permission suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Table of contents
       - [Resources](#resources)
         - [Default](#default)
         - [Custom Permissions](#custom-permissions)
+          - [Custom Permissions Suffix](#custom-permissions-suffix)
       - [Pages](#pages)
           - [Pages Hooks](#pages-hooks)
           - [Pages Redirect Path](#pages-redirect-path)
@@ -304,6 +305,31 @@ In the above example the `getPermissionPrefixes()` method returns the permission
     'publish' => 'Publicar'    
 ],
 ```
+
+###### Custom Permissions Suffix
+
+You can also customize the suffix for `Resource` permissions. For example if you have a `CategoryResource` in the `Resources\Tenant\Blog` directory, by default suffix for all permissions will be `tenant::blog::category`, but you can change it to be shorter, like `category`.
+
+```php
+<?php
+
+namespace BezhanSalleh\FilamentShield\Resources\Tenant\Blog;
+
+...
+
+class CategoryResource extends Resource
+{
+    ...
+
+    public static function getPermissionSuffix(): string
+    {
+        return 'category';
+    }
+
+    ...
+}
+```
+✅ In this way all permission names will be shorter. For example instead of the default `force_delete_tenant::blog::category` you will have `force_delete_category`;
 
 #### Pages
 

--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -94,7 +94,12 @@ class FilamentShield
                 return true;
             })
             ->reduce(function ($resources, $resource) {
-                $name = Str::of($resource)->afterLast('Resources\\')->before('Resource')->replace('\\', '')->headline()->snake()->replace('_', '::');
+                if (static::hasPermissionSuffix($resource)) {
+                    $name = $resource::getPermissionSuffix();
+                } else {
+                    $name = Str::of($resource)->afterLast('Resources\\')->before('Resource')->replace('\\', '')->headline()->snake()->replace('_', '::');
+                }
+
                 $resources["{$name}"] = [
                     'resource' => "{$name}",
                     'model' => Str::of($resource::getModel())->afterLast('\\'),
@@ -249,5 +254,10 @@ class FilamentShield
     protected static function hasHeadingForShield(object|string $class): bool
     {
         return method_exists($class, 'getHeadingForShield');
+    }
+
+    protected static function hasPermissionSuffix(object|string $class): bool
+    {
+        return method_exists($class, 'getPermissionSuffix');
     }
 }


### PR DESCRIPTION
Added possibility to customize the suffix for `Resource` permissions. 

For example if you have a `CategoryResource` in the `Resources\Tenant\Blog` directory, by default suffix for all permissions will be `tenant::blog::category`, but you can change it to be shorter, like `category`.

```php
<?php

namespace BezhanSalleh\FilamentShield\Resources\Tenant\Blog;

...

class CategoryResource extends Resource
{
    ...

    public static function getPermissionSuffix(): string
    {
        return 'category';
    }

    ...
}
```
✅ In this way all permission names will be shorter. For example instead of the default `force_delete_tenant::blog::category` you will have `force_delete_category`;