### PR TITLE
Typo in example for custom permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ namespace BezhanSalleh\FilamentShield\Resources;
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
 ...
 
-class RoleResource extends Resource implements HasShieldPermissions
+class PostResource extends Resource implements HasShieldPermissions
 {
     ...
 


### PR DESCRIPTION
The text explaining is referencing the "PostResource", but the example was showing the "Role Resource"