### PR TITLE
Update ShieldSeeder.stub

### DIFF
--- a/stubs/ShieldSeeder.stub
+++ b/stubs/ShieldSeeder.stub
@@ -37,10 +37,18 @@ class ShieldSeeder extends Seeder
                     'guard_name' => $rolePlusPermission['guard_name']
                 ]);
 
-                if (! blank($rolePlusPermission['permissions'])) {
+                if (!blank($permissions = $rolePlusPermission['permissions'])) {
+
+                    foreach ($permissions as $permission) {
+                        if (Permission::whereName($permission)->doesntExist()) {
+                            Permission::create([
+                                'name' => $permission,
+                                'guard_name' => $rolePlusPermission['guard_name'],
+                            ]);
+                        }
+                    }
 
                     $role->givePermissionTo($rolePlusPermission['permissions']);
-
                 }
             }
         }


### PR DESCRIPTION
I came across an error while publishing the seeder and running it. After checking the code, I figured out that the seeder was not creating the permissions before trying to attach them to the role.

The error message was: 

```
There is no permission named `view_event` for guard `web`.
```