### PR TITLE
refactor: make getResourceNavigationSort nullable

### DIFF
--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -32,7 +32,7 @@ class Utils
         return config('filament-shield.shield_resource.should_register_navigation', true);
     }
 
-    public static function getResourceNavigationSort(): int
+    public static function getResourceNavigationSort(): ?int
     {
         return config('filament-shield.shield_resource.navigation_sort');
     }


### PR DESCRIPTION
A resource's navigation sort is nullable (see `\BezhanSalleh\FilamentShield\Resources\RoleResource::getNavigationSort`), so the util should also support `null`. This will use Filament's default sorting.