### PR TITLE
Feature/configure permission identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `filament-shield` will be documented in this file.
 
+## 2.4.2 - 2023-02-10
+
+### What's Changed
+
+- Fixes #172 by @bezhanSalleh in https://github.com/bezhanSalleh/filament-shield/pull/176
+
+**Full Changelog**: https://github.com/bezhanSalleh/filament-shield/compare/2.4.1...2.4.2
+
 ## 2.4.1 - 2023-02-10
 
 ### What's Changed
@@ -178,7 +186,9 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- 
 - - new options for `shield:generate`
+- 
 - 
 - 
 - 
@@ -313,6 +323,22 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- - 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
 - - - --option[=OPTION]        Override the config generator option(policies_and_permissions,policies,permissions)
 - - 
 - 
@@ -419,6 +445,22 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - - 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- - 
+- 
 - 
 - 
 - 
@@ -553,6 +595,22 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- - 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
 - - - --page[=PAGE]            One or many pages separated by comma (,)
 - - 
 - 
@@ -659,6 +717,22 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - - 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- - 
+- 
 - 
 - 
 - 
@@ -793,6 +867,22 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- - 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
 - - - --exclude                Exclude the given entities during generation
 - - 
 - 
@@ -899,6 +989,22 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - - 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- - 
+- 
 - 
 - 
 - 
@@ -1048,7 +1154,25 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- 
+- - 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
 - - new option for `shield:install`
+- 
 - 
 - 
 - 
@@ -1198,7 +1322,25 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- 
+- - 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
+- 
 - - redefined the purpose of `filament_user` role, not attaching permissions anymore
+- 
 - 
 - 
 - 
@@ -1339,7 +1481,9 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- 
 - - Add Setting Model (DB)
+- 
 - 
 - 
 - 
@@ -1389,7 +1533,9 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- 
 - - Remove Config file
+- 
 - 
 - 
 - 
@@ -1439,7 +1585,9 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- 
 - - Make default permissions translatable
+- 
 - 
 - 
 - 
@@ -1489,6 +1637,7 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- 
 - - Remove `shield:publish` command
 - 
 - 
@@ -1514,7 +1663,9 @@ All notable changes to `filament-shield` will be documented in this file.
 - 
 - 
 - 
+- 
 - - Remove `RoleResource` stubs
+- 
 - 
 - 
 - 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Table of contents
       - [Resources](#resources)
         - [Default](#default)
         - [Custom Permissions](#custom-permissions)
+        - [Configure Permission Identifier](#configure-permission-identifier)
       - [Pages](#pages)
           - [Pages Hooks](#pages-hooks)
           - [Pages Redirect Path](#pages-redirect-path)
@@ -306,6 +307,35 @@ In the above example the `getPermissionPrefixes()` method returns the permission
     'publish' => 'Publicar'    
 ],
 ```
+
+##### Configure Permission Identifier
+By default the permission identifier is generated as follow:
+```php
+Str::of($resource)
+    ->afterLast('Resources\\')
+    ->before('Resource')
+    ->replace('\\', '')
+    ->snake()
+    ->replace('_', '::');
+```
+So for instance if you have a resource like `App\Filament\Resources\Shop\CategoryResource` then the permission identifier would be `shop::category` and then it would be prefixed with your defined prefixex or what comes default with shield.
+
+If you wish to change the default behaviour, then you can call the static `configurePermissionIdentifierUsing()` method inside a service provider's `boot()` method, to which you pass a Closure to modify the logic. The Closure receives the fully qualified class name as `$resource` which gives you the ability to access any property or method defined within the resource.
+
+For example, if you wish to use the model name as the permission identifier, you can do it like so:
+
+```php
+use BezhanSalleh\FilamentShield\Facades\FilamentShield;
+
+FilamentShield::configurePermissionIdentifierUsing(
+    fn($resource) => str($resource::getModel())
+        ->afterLast('\\')
+        ->lower()
+        ->toString()
+);
+```
+> **Warning**
+> Keep in mind that ensuring the uniqueness of the permission identifier is up to you now.
 
 #### Pages
 

--- a/src/Commands/Concerns/CanGeneratePolicy.php
+++ b/src/Commands/Concerns/CanGeneratePolicy.php
@@ -25,8 +25,8 @@ trait CanGeneratePolicy
         if (Str::of($path)->contains(['vendor', 'src'])) {
             $basePolicyPath = app_path(
                 (string) Str::of($entity['model'])
-                ->prepend('Policies\\')
-                ->replace('\\', DIRECTORY_SEPARATOR),
+                    ->prepend('Policies\\')
+                    ->replace('\\', DIRECTORY_SEPARATOR),
             );
 
             return "{$basePolicyPath}Policy.php";

--- a/src/Commands/MakeShieldGenerateCommand.php
+++ b/src/Commands/MakeShieldGenerateCommand.php
@@ -187,7 +187,7 @@ class MakeShieldGenerateCommand extends Command
 
     protected function generateForResources(array $resources): Collection
     {
-        return  collect($resources)
+        return collect($resources)
             ->values()
             ->each(function ($entity) {
                 if ($this->generatorOption === 'policies_and_permissions') {

--- a/src/Commands/MakeShieldGenerateCommand.php
+++ b/src/Commands/MakeShieldGenerateCommand.php
@@ -2,7 +2,7 @@
 
 namespace BezhanSalleh\FilamentShield\Commands;
 
-use BezhanSalleh\FilamentShield\FilamentShield;
+use BezhanSalleh\FilamentShield\Facades\FilamentShield;
 use BezhanSalleh\FilamentShield\Support\Utils;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
@@ -48,7 +48,7 @@ class MakeShieldGenerateCommand extends Command
 
     protected $onlyPages = false;
 
-    protected $onlyWidget = false;
+    protected $onlyWidgets = false;
 
     /**
      * The console command signature.

--- a/src/Commands/MakeShieldInstallCommand.php
+++ b/src/Commands/MakeShieldInstallCommand.php
@@ -79,10 +79,10 @@ class MakeShieldInstallCommand extends Command
     protected function CheckIfAlreadyInstalled(): bool
     {
         $count = $this->getTables()
-                ->filter(function ($table) {
-                    return Schema::hasTable($table);
-                })
-                ->count();
+            ->filter(function ($table) {
+                return Schema::hasTable($table);
+            })
+            ->count();
         if ($count !== 0) {
             return true;
         }

--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -293,7 +293,6 @@ class FilamentShield
                 ->afterLast('Resources\\')
                 ->before('Resource')
                 ->replace('\\', '')
-                ->headline()
                 ->snake()
                 ->replace('_', '::');
     }

--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -27,13 +27,14 @@ class FilamentShield
 
     public function getPermissionIdentifier(string $resource): string
     {
-        if (blank($this->configurePermissionIdentifierUsing)) {
-            return Str::of($resource)->afterLast('Resources\\')->before('Resource')->replace('\\', '')->headline()->snake()->replace('_', '::');
-        }
-
-        return $this->evaluate($this->configurePermissionIdentifierUsing, [
-            'resource' => $resource,
-        ]);
+        return $this->configurePermissionIdentifierUsing
+            ? $this->evaluate(
+                value: $this->configurePermissionIdentifierUsing,
+                parameters: [
+                    'resource' => $resource,
+                ]
+            )
+            : Str::of($resource)->afterLast('Resources\\')->before('Resource')->replace('\\', '')->headline()->snake()->replace('_', '::');
     }
 
     public function generateForResource(array $entity): void

--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -280,10 +280,10 @@ class FilamentShield
     protected function getDefaultPermissionIdentifier(string $resource): string
     {
         return Str::of($resource)
-                ->afterLast('Resources\\')
-                ->before('Resource')
-                ->replace('\\', '')
-                ->snake()
-                ->replace('_', '::');
+            ->afterLast('Resources\\')
+            ->before('Resource')
+            ->replace('\\', '')
+            ->snake()
+            ->replace('_', '::');
     }
 }

--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -2,16 +2,15 @@
 
 namespace BezhanSalleh\FilamentShield;
 
+use BezhanSalleh\FilamentShield\Support\Utils;
 use Closure;
-use Illuminate\Support\Str;
 use Filament\Facades\Filament;
 use Filament\Resources\Resource;
+use Filament\Support\Concerns\EvaluatesClosures;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Str;
 use Spatie\Permission\PermissionRegistrar;
-use BezhanSalleh\FilamentShield\Support\Utils;
-use Filament\Support\Concerns\EvaluatesClosures;
-
 
 class FilamentShield
 {
@@ -145,9 +144,6 @@ class FilamentShield
 
     /**
      * Get the localized resource label
-     *
-     * @param  string  $entity
-     * @return string
      */
     public static function getLocalizedResourceLabel(string $entity): string
     {
@@ -160,9 +156,6 @@ class FilamentShield
 
     /**
      * Get the localized resource permission label
-     *
-     * @param  string  $permission
-     * @return string
      */
     public static function getLocalizedResourcePermissionLabel(string $permission): string
     {
@@ -200,9 +193,6 @@ class FilamentShield
 
     /**
      * Get localized page label
-     *
-     * @param  string  $page
-     * @return string|bool
      */
     public static function getLocalizedPageLabel(string $page): string|bool
     {

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -78,11 +78,11 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     'sm' => 2,
                                     'lg' => 3,
                                 ])
-                                ->schema(static::getResourceEntitiesSchema())
-                                ->columns([
-                                    'sm' => 2,
-                                    'lg' => 3,
-                                ]),
+                                    ->schema(static::getResourceEntitiesSchema())
+                                    ->columns([
+                                        'sm' => 2,
+                                        'lg' => 3,
+                                    ]),
                             ]),
                         Forms\Components\Tabs\Tab::make(__('filament-shield::filament-shield.pages'))
                             ->visible(fn (): bool => (bool) Utils::isPageEntityEnabled() && (count(FilamentShield::getPages()) > 0 ? true : false))
@@ -92,11 +92,11 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     'sm' => 3,
                                     'lg' => 4,
                                 ])
-                                ->schema(static::getPageEntityPermissionsSchema())
-                                ->columns([
-                                    'sm' => 3,
-                                    'lg' => 4,
-                                ]),
+                                    ->schema(static::getPageEntityPermissionsSchema())
+                                    ->columns([
+                                        'sm' => 3,
+                                        'lg' => 4,
+                                    ]),
                             ]),
                         Forms\Components\Tabs\Tab::make(__('filament-shield::filament-shield.widgets'))
                             ->visible(fn (): bool => (bool) Utils::isWidgetEntityEnabled() && (count(FilamentShield::getWidgets()) > 0 ? true : false))
@@ -106,11 +106,11 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     'sm' => 3,
                                     'lg' => 4,
                                 ])
-                                ->schema(static::getWidgetEntityPermissionSchema())
-                                ->columns([
-                                    'sm' => 3,
-                                    'lg' => 4,
-                                ]),
+                                    ->schema(static::getWidgetEntityPermissionSchema())
+                                    ->columns([
+                                        'sm' => 3,
+                                        'lg' => 4,
+                                    ]),
                             ]),
 
                         Forms\Components\Tabs\Tab::make(__('filament-shield::filament-shield.custom'))
@@ -121,11 +121,11 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     'sm' => 3,
                                     'lg' => 4,
                                 ])
-                                ->schema(static::getCustomEntitiesPermisssionSchema())
-                                ->columns([
-                                    'sm' => 3,
-                                    'lg' => 4,
-                                ]),
+                                    ->schema(static::getCustomEntitiesPermisssionSchema())
+                                    ->columns([
+                                        'sm' => 3,
+                                        'lg' => 4,
+                                    ]),
                             ]),
                     ])
                     ->columnSpan('full'),
@@ -252,27 +252,27 @@ class RoleResource extends Resource implements HasShieldPermissions
 
         return collect(FilamentShield::getResources())->sortKeys()->reduce(function ($entities, $entity) {
             $entities[] = Forms\Components\Card::make()
-                    ->extraAttributes(['class' => 'border-0 shadow-lg'])
-                    ->schema([
-                        Forms\Components\Toggle::make($entity['resource'])
-                            ->label(FilamentShield::getLocalizedResourceLabel($entity['fqcn']))
-                            ->helperText(Utils::showModelPath($entity['fqcn']))
-                            ->onIcon('heroicon-s-lock-open')
-                            ->offIcon('heroicon-s-lock-closed')
-                            ->reactive()
-                            ->afterStateUpdated(function (Closure $set, Closure $get, $state) use ($entity) {
-                                collect(Utils::getResourcePermissionPrefixes($entity['fqcn']))->each(function ($permission) use ($set, $entity, $state) {
-                                    $set($permission.'_'.$entity['resource'], $state);
-                                });
+                ->extraAttributes(['class' => 'border-0 shadow-lg'])
+                ->schema([
+                    Forms\Components\Toggle::make($entity['resource'])
+                        ->label(FilamentShield::getLocalizedResourceLabel($entity['fqcn']))
+                        ->helperText(Utils::showModelPath($entity['fqcn']))
+                        ->onIcon('heroicon-s-lock-open')
+                        ->offIcon('heroicon-s-lock-closed')
+                        ->reactive()
+                        ->afterStateUpdated(function (Closure $set, Closure $get, $state) use ($entity) {
+                            collect(Utils::getResourcePermissionPrefixes($entity['fqcn']))->each(function ($permission) use ($set, $entity, $state) {
+                                $set($permission.'_'.$entity['resource'], $state);
+                            });
 
-                                if (! $state) {
-                                    $set('select_all', false);
-                                }
+                            if (! $state) {
+                                $set('select_all', false);
+                            }
 
-                                static::refreshSelectAllStateViaEntities($set, $get);
-                            })
-                            ->dehydrated(false),
-                        Forms\Components\Fieldset::make('Permissions')
+                            static::refreshSelectAllStateViaEntities($set, $get);
+                        })
+                        ->dehydrated(false),
+                    Forms\Components\Fieldset::make('Permissions')
                         ->label(__('filament-shield::filament-shield.column.permissions'))
                         ->extraAttributes(['class' => 'text-primary-600', 'style' => 'border-color:var(--primary)'])
                         ->columns([
@@ -280,12 +280,12 @@ class RoleResource extends Resource implements HasShieldPermissions
                             'xl' => 2,
                         ])
                         ->schema(static::getResourceEntityPermissionsSchema($entity)),
-                    ])
-                    ->columnSpan(1);
+                ])
+                ->columnSpan(1);
 
             return $entities;
         }, collect())
-        ->toArray();
+            ->toArray();
     }
 
     public static function getResourceEntityPermissionsSchema($entity): ?array
@@ -320,7 +320,7 @@ class RoleResource extends Resource implements HasShieldPermissions
 
             return $permissions;
         }, collect())
-        ->toArray();
+            ->toArray();
     }
 
     protected static function refreshSelectAllStateViaEntities(Closure $set, Closure $get): void
@@ -433,31 +433,31 @@ class RoleResource extends Resource implements HasShieldPermissions
     {
         return collect(FilamentShield::getPages())->sortKeys()->reduce(function ($pages, $page) {
             $pages[] = Forms\Components\Grid::make()
-                    ->schema([
-                        Forms\Components\Checkbox::make($page)
-                            ->label(FilamentShield::getLocalizedPageLabel($page))
-                            ->inline()
-                            ->afterStateHydrated(function (Closure $set, Closure $get, $record) use ($page) {
-                                if (is_null($record)) {
-                                    return;
-                                }
+                ->schema([
+                    Forms\Components\Checkbox::make($page)
+                        ->label(FilamentShield::getLocalizedPageLabel($page))
+                        ->inline()
+                        ->afterStateHydrated(function (Closure $set, Closure $get, $record) use ($page) {
+                            if (is_null($record)) {
+                                return;
+                            }
 
-                                $set($page, $record->checkPermissionTo($page));
+                            $set($page, $record->checkPermissionTo($page));
 
-                                static::refreshSelectAllStateViaEntities($set, $get);
-                            })
-                            ->reactive()
-                            ->afterStateUpdated(function (Closure $set, Closure $get, $state) {
-                                if (! $state) {
-                                    $set('select_all', false);
-                                }
+                            static::refreshSelectAllStateViaEntities($set, $get);
+                        })
+                        ->reactive()
+                        ->afterStateUpdated(function (Closure $set, Closure $get, $state) {
+                            if (! $state) {
+                                $set('select_all', false);
+                            }
 
-                                static::refreshSelectAllStateViaEntities($set, $get);
-                            })
-                            ->dehydrated(fn ($state): bool => $state),
-                    ])
-                    ->columns(1)
-                    ->columnSpan(1);
+                            static::refreshSelectAllStateViaEntities($set, $get);
+                        })
+                        ->dehydrated(fn ($state): bool => $state),
+                ])
+                ->columns(1)
+                ->columnSpan(1);
 
             return $pages;
         }, []);
@@ -474,31 +474,31 @@ class RoleResource extends Resource implements HasShieldPermissions
     {
         return collect(FilamentShield::getWidgets())->reduce(function ($widgets, $widget) {
             $widgets[] = Forms\Components\Grid::make()
-                    ->schema([
-                        Forms\Components\Checkbox::make($widget)
-                            ->label(FilamentShield::getLocalizedWidgetLabel($widget))
-                            ->inline()
-                            ->afterStateHydrated(function (Closure $set, Closure $get, $record) use ($widget) {
-                                if (is_null($record)) {
-                                    return;
-                                }
+                ->schema([
+                    Forms\Components\Checkbox::make($widget)
+                        ->label(FilamentShield::getLocalizedWidgetLabel($widget))
+                        ->inline()
+                        ->afterStateHydrated(function (Closure $set, Closure $get, $record) use ($widget) {
+                            if (is_null($record)) {
+                                return;
+                            }
 
-                                $set($widget, $record->checkPermissionTo($widget));
+                            $set($widget, $record->checkPermissionTo($widget));
 
-                                static::refreshSelectAllStateViaEntities($set, $get);
-                            })
-                            ->reactive()
-                            ->afterStateUpdated(function (Closure $set, Closure $get, $state) {
-                                if (! $state) {
-                                    $set('select_all', false);
-                                }
+                            static::refreshSelectAllStateViaEntities($set, $get);
+                        })
+                        ->reactive()
+                        ->afterStateUpdated(function (Closure $set, Closure $get, $state) {
+                            if (! $state) {
+                                $set('select_all', false);
+                            }
 
-                                static::refreshSelectAllStateViaEntities($set, $get);
-                            })
-                            ->dehydrated(fn ($state): bool => $state),
-                    ])
-                    ->columns(1)
-                    ->columnSpan(1);
+                            static::refreshSelectAllStateViaEntities($set, $get);
+                        })
+                        ->dehydrated(fn ($state): bool => $state),
+                ])
+                ->columns(1)
+                ->columnSpan(1);
 
             return $widgets;
         }, []);
@@ -528,31 +528,31 @@ class RoleResource extends Resource implements HasShieldPermissions
     {
         return collect(static::getCustomEntities())->reduce(function ($customEntities, $customPermission) {
             $customEntities[] = Forms\Components\Grid::make()
-                    ->schema([
-                        Forms\Components\Checkbox::make($customPermission)
-                            ->label(Str::of($customPermission)->headline())
-                            ->inline()
-                            ->afterStateHydrated(function (Closure $set, Closure $get, $record) use ($customPermission) {
-                                if (is_null($record)) {
-                                    return;
-                                }
+                ->schema([
+                    Forms\Components\Checkbox::make($customPermission)
+                        ->label(Str::of($customPermission)->headline())
+                        ->inline()
+                        ->afterStateHydrated(function (Closure $set, Closure $get, $record) use ($customPermission) {
+                            if (is_null($record)) {
+                                return;
+                            }
 
-                                $set($customPermission, $record->checkPermissionTo($customPermission));
+                            $set($customPermission, $record->checkPermissionTo($customPermission));
 
-                                static::refreshSelectAllStateViaEntities($set, $get);
-                            })
-                            ->reactive()
-                            ->afterStateUpdated(function (Closure $set, Closure $get, $state) {
-                                if (! $state) {
-                                    $set('select_all', false);
-                                }
+                            static::refreshSelectAllStateViaEntities($set, $get);
+                        })
+                        ->reactive()
+                        ->afterStateUpdated(function (Closure $set, Closure $get, $state) {
+                            if (! $state) {
+                                $set('select_all', false);
+                            }
 
-                                static::refreshSelectAllStateViaEntities($set, $get);
-                            })
-                            ->dehydrated(fn ($state): bool => $state),
-                    ])
-                    ->columns(1)
-                    ->columnSpan(1);
+                            static::refreshSelectAllStateViaEntities($set, $get);
+                        })
+                        ->dehydrated(fn ($state): bool => $state),
+                ])
+                ->columns(1)
+                ->columnSpan(1);
 
             return $customEntities;
         }, []);

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -3,7 +3,7 @@
 namespace BezhanSalleh\FilamentShield\Resources;
 
 use BezhanSalleh\FilamentShield\Contracts\HasShieldPermissions;
-use BezhanSalleh\FilamentShield\FilamentShield;
+use BezhanSalleh\FilamentShield\Facades\FilamentShield;
 use BezhanSalleh\FilamentShield\Resources\RoleResource\Pages;
 use BezhanSalleh\FilamentShield\Support\Utils;
 use Closure;

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -120,8 +120,6 @@ class Utils
 
     /**
      * Widget Entity Status
-     *
-     * @return bool
      */
     public static function isWidgetEntityEnabled(): bool
     {

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -16,7 +16,7 @@ it('can check if the permission name can be configured using the closure', funct
     // expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role::resource');
 
     FilamentShield::configurePermissionIdentifierUsing(
-        fn($resource) => str($resource::getModel())
+        fn ($resource) => str($resource::getModel())
             ->afterLast('\\')
             ->lower()
             ->toString()

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -10,8 +10,17 @@ it('can check if package testing is configured', function () {
 it('can check if the permission name can be configured using the closure', function() {
     $resource = RoleResource::class;
 
-    FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '.'));
-    expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role.resource');
-    FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '::'));
-    expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role::resource');
+    // FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '.'));
+    // expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role.resource');
+    // FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '::'));
+    // expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role::resource');
+
+    FilamentShield::configurePermissionIdentifierUsing(
+        fn($resource) => str($resource::getModel())
+            ->afterLast('\\')
+            ->lower()
+            ->toString()
+    );
+
+    expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role');
 });

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -1,5 +1,15 @@
 <?php
 
+use BezhanSalleh\FilamentShield\Facades\FilamentShield;
+use BezhanSalleh\FilamentShield\Resources\RoleResource;
+
 it('can check if package testing is configured', function () {
     expect(true)->toBeTrue();
+});
+
+it('can check if the permission name can be configured using the closure', function() {
+    $resource = RoleResource::class;
+
+    // FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '.'));
+    expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role');
 });

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -10,6 +10,8 @@ it('can check if package testing is configured', function () {
 it('can check if the permission name can be configured using the closure', function() {
     $resource = RoleResource::class;
 
-    // FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '.'));
-    expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role');
+    FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '.'));
+    expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role.resource');
+    FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '::'));
+    expect(FilamentShield::getPermissionIdentifier($resource))->toBe('role::resource');
 });

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -7,7 +7,7 @@ it('can check if package testing is configured', function () {
     expect(true)->toBeTrue();
 });
 
-it('can check if the permission name can be configured using the closure', function() {
+it('can check if the permission name can be configured using the closure', function () {
     $resource = RoleResource::class;
 
     // FilamentShield::configurePermissionIdentifierUsing(fn () => str($resource)->afterLast('Resources\\')->replace('\\', '')->headline()->snake()->replace('_', '.'));


### PR DESCRIPTION
##### Configure Permission Identifier
By default the permission identifier is generated as follow:
```php
Str::of($resource)
    ->afterLast('Resources\\')
    ->before('Resource')
    ->replace('\\', '')
    ->snake()
    ->replace('_', '::');
```
So for instance if you have a resource like `App\Filament\Resources\Shop\CategoryResource` then the permission identifier would be `shop::category` and then it would be prefixed with your defined prefixes or what comes default with shield.

If you wish to change the default behaviour, then you can call the static `configurePermissionIdentifierUsing()` method inside a service provider's `boot()` method, to which you pass a Closure to modify the logic. The Closure receives the fully qualified class name of the resource as `$resource` which gives you the ability to access any property or method defined within the resource.

For example, if you wish to use the model name as the permission identifier, you can do it like so:

```php
use BezhanSalleh\FilamentShield\Facades\FilamentShield;

FilamentShield::configurePermissionIdentifierUsing(
    fn($resource) => str($resource::getModel())
        ->afterLast('\\')
        ->lower()
        ->toString()
);
```
> **Warning**
> Keep in mind that ensuring the uniqueness of the permission identifier is now up to you.