### PR TITLE
fix getting label name from wrong class

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -263,13 +263,10 @@ class FilamentShield
 
     protected static function transformClassString(string $string, bool $isPageClass = true): string
     {
+        $prefix = Str::of($isPageClass ? Utils::getPagePermissionPrefix() : Utils::getWidgetPermissionPrefix())->append('_');
+
         return (string) collect($isPageClass ? Filament::getPages() : Filament::getWidgets())
-            ->first(fn ($item) => Str::endsWith(
-                $item,
-                Str::of($string)
-                    ->after('_')
-                    ->studly()
-            ));
+            ->first(fn ($item) => class_basename($item) == Str::of($string)->after($prefix)->studly());
     }
 
     protected static function hasHeadingForShield(object|string $class): bool


### PR DESCRIPTION
current check for class name is a loosely check as it checks for `endsWith`, this PR looks to fix this

in my app there is this permission "view_Search"

and having these pages (from `Filament::getPages()`)
```php
[
  0 => "RyanChandler\FilamentProfile\Pages\Profile",
  1 => "App\Filament\Pages\Dashboard",
  2 => "App\Filament\Pages\ManageSearch",
  3 => "App\Filament\Pages\ManageSite",
  4 => "App\Filament\Pages\MarketValue\ListCars",
  5 => "App\Filament\Pages\MarketValue\ShowCar",
  6 => "App\Filament\Pages\Search"
];
```

the current code only take the first class name thats end with "Search" resulted to this
![image](https://github.com/bezhanSalleh/filament-shield/assets/67364036/75eef198-008a-4073-a369-006c9dd704e9)

**after fix**
![image](https://github.com/bezhanSalleh/filament-shield/assets/67364036/fb5bbb53-c737-44fc-9cd9-7f07a88c9a3c)
