### PR TITLE
Support User model inheritance and configuration of the `HasRoles` trait in the parent model

### DIFF
--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -66,7 +66,7 @@ class Utils
 
     public static function isAuthProviderConfigured(): bool
     {
-        return in_array("Spatie\Permission\Traits\HasRoles", class_uses(static::getAuthProviderFQCN()));
+        return in_array("Spatie\Permission\Traits\HasRoles", class_uses_recursive(static::getAuthProviderFQCN()));
     }
 
     public static function isSuperAdminEnabled(): bool


### PR DESCRIPTION
- Use `class_uses_recursive()` when checking if the Auth provider has `HasRoles` trait. 
- This allows configuration of the HasRoles trait somewhere else and using inheritance, for example if a user prefers to extract most of the configuration for `App\Models\User` to another common trait

**A use case would be:**
- Configure most of the user traits and relationships in a User model inside a module for portability
- Include `HasRoles` as part of this configuration
- From `App\Models\User`, simply extend `Modules\Core\app\Models\User` with the trait already configured.