### PR TITLE
Some other widget packages use private classes for widgets - this fixes that

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -284,7 +284,7 @@ class FilamentShield
 
         return match (true) {
             $widgetInstance instanceof TableWidget => (string) invade($widgetInstance)->makeTable()->getHeading(),
-            ! ($widgetInstance instanceof TableWidget) && $widgetInstance instanceof Widget && method_exists($widgetInstance, 'getHeading') => (string) $widgetInstance->getHeading(),
+            ! ($widgetInstance instanceof TableWidget) && $widgetInstance instanceof Widget && method_exists($widgetInstance, 'getHeading') => (string) invade($widgetInstance)->getHeading(),
             default => Str::of($widget)
                 ->after(Utils::getWidgetPermissionPrefix() . '_')
                 ->headline()


### PR DESCRIPTION
Packages such as filament-apexcharts use private functions for getHeading() etc, which means this doesn't work.

This fixes that.