### PR TITLE
Fix: wrong role_count badge when tenancy is enabled.

### DIFF
--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -303,7 +303,7 @@ class RoleResource extends Resource implements HasShieldPermissions
     public static function getNavigationBadge(): ?string
     {
         return Utils::isResourceNavigationBadgeEnabled()
-            ? static::getModel()::count()
+            ? static::getEloquentQuery()->count()
             : null;
     }
 


### PR DESCRIPTION
I don't think that any explanation is needed.