### PR TITLE
Fixed TableWidget getHeading

### DIFF
--- a/resources/lang/uk/filament-shield.php
+++ b/resources/lang/uk/filament-shield.php
@@ -19,8 +19,8 @@ return [
     |------------------------------------------------- -------------------------
     */
 
-    'field.name' => 'Ім\'я',
-    'field.guard_name' => 'Ім\'я гварда',
+    'field.name' => 'Назва',
+    'field.guard_name' => 'Назва гварда',
     'field.permissions' => 'Дозволи',
     'field.select_all.name' => 'Вибрати все',
     'field.select_all.message' => 'Включити всі дозволи, які <span class="text-primary font-medium">Доступні</span> для цієї ролі',
@@ -65,16 +65,16 @@ return [
 
     'resource_permission_prefixes_labels' => [
         'view' => 'Перегляд',
-        'view_any' => 'Може дивитися будь-яке',
-        'create' => 'Створення',
-        'update' => 'Оновлення',
-        'delete' => 'Видалення',
-        'delete_any' => 'Може видалити будь-який',
-        'force_delete' => 'Примусово видалити',
-        'force_delete_any' => 'Може примусово видалити будь-який',
-        'restore' => 'Відновлення',
-        'reorder' => 'Зміна порядку',
-        'restore_any' => 'Може відновити будь-який',
+        'view_any' => 'Перегляд будь-якого',
+        'create' => 'Створити',
+        'update' => 'Оновити',
+        'delete' => 'Видалити',
+        'delete_any' => 'Видалити будь-яке',
+        'force_delete' => 'Примусове видалення',
+        'force_delete_any' => 'Примусово видалити будь-яке',
+        'restore' => 'Відновити',
+        'reorder' => 'Змінити порядок',
+        'restore_any' => 'Відновити будь-яке',
         'replicate' => 'Копіювати',
     ],
 ];

--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -279,17 +279,22 @@ class FilamentShield
     public static function getLocalizedWidgetLabel(string $widget): string
     {
         $class = static::transformClassString($widget, false);
-
         $widgetInstance = app()->make($class);
 
-        return match (true) {
-            $widgetInstance instanceof TableWidget => (string) invade($widgetInstance)->makeTable()->getHeading(),
-            ! ($widgetInstance instanceof TableWidget) && $widgetInstance instanceof Widget && method_exists($widgetInstance, 'getHeading') => (string) invade($widgetInstance)->getHeading(),
-            default => Str::of($widget)
-                ->after(Utils::getWidgetPermissionPrefix() . '_')
-                ->headline()
-                ->toString(),
-        };
+        if ($widgetInstance instanceof TableWidget) {
+            $invadedInstance = invade($widgetInstance);
+            $table = $invadedInstance->table($invadedInstance->makeTable());
+            return (string) $table->getHeading();
+        }
+
+        if ($widgetInstance instanceof Widget && method_exists($widgetInstance, 'getHeading')) {
+            return (string) $widgetInstance->getHeading();
+        }
+
+        return Str::of($widget)
+            ->after(Utils::getWidgetPermissionPrefix() . '_')
+            ->headline()
+            ->toString();
     }
 
     protected static function transformClassString(string $string, bool $isPageClass = true): string


### PR DESCRIPTION
the `getLocalizedWidgetLabel` must call `table` method in order to get the custom heading.

```php
invade($widgetInstance)->table(invade($widgetInstance)->makeTable())->getHeading()
```


Custom heading:
<img width="599" alt="Screenshot 2024-01-05 at 14 02 29" src="https://github.com/bezhanSalleh/filament-shield/assets/142592979/97c563db-39bd-4767-b4d4-2b556338f9af">
