### PR TITLE
fix assign Role for Multi-tenancy installation

### DIFF
--- a/src/Commands/MakeShieldSuperAdminCommand.php
+++ b/src/Commands/MakeShieldSuperAdminCommand.php
@@ -84,7 +84,14 @@ class MakeShieldSuperAdminCommand extends Command
             $this->superAdmin = $this->createSuperAdmin();
         }
 
-        $this->superAdmin->assignRole(Utils::getSuperAdminName());
+        if (config('permission.teams')) {
+            foreach ($this->superAdmin->teams as $team) {
+                setPermissionsTeamId($team->id);
+                $this->superAdmin->assignRole(Utils::getSuperAdminName());
+            }
+        } else {
+            $this->superAdmin->assignRole(Utils::getSuperAdminName());
+        }
 
         $loginUrl = Filament::getCurrentPanel()?->getLoginUrl();
 


### PR DESCRIPTION
Hello, 

 I am using a multi-tenant configuration

The database already contains users

Then call   `php artisan shield:install` or `php artisan shield:install --fresh`

I got this error: 

```


 ┌ Please provide the `UserID` to be set as `super_admin` ──────┐
 │ 1                                                            │
 └──────────────────────────────────────────────────────────────┘


   Illuminate\Database\QueryException

  SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'team_id' cannot be null (Connection: mysql, SQL: insert into `model_has_roles` (`model_id`, `model_type`, `role_id`, `team_id`) values (1, App\Models\User, 1, ?))

  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:822
    818▕                     $this->getName(), $query, $this->prepareBindings($bindings), $e
    819▕                 );
    820▕             }
    821▕
  ➜ 822▕             throw new QueryException(
    823▕                 $this->getName(), $query, $this->prepareBindings($bindings), $e
    824▕             );
    825▕         }
    826▕     }

      +34 vendor frames

  35  artisan:35
      Illuminate\Foundation\Console\Kernel::handle()


```

And table  'model_has_roles' is empty and inside the panel, I don't see any resources....

The problem is that when calling
```php
   $this->superAdmin->assignRole(Utils::getSuperAdminName());
```
the system cannot determine the current temap_id ..

 
spatie  laravel-permission suggests recording team_id in the session via  Middleware https://spatie.be/docs/laravel-permission/v6/basic-usage/teams-permissions
 
