### PR TITLE
Feature/performance boost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
     ],
     "require": {
         "php": "^8.1",
-        "filament/filament": "^3.0",
+        "filament/filament": "^3.2",
         "spatie/laravel-package-tools": "^1.9",
         "spatie/laravel-permission": "^6.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0",
-        "nunomaduro/larastan": "^2.1",
+        "larastan/larastan": "^2.0",
         "orchestra/testbench": "^8.0",
         "pestphp/pest": "^2.10",
         "phpstan/extension-installer": "^1.3",

--- a/resources/views/forms/shield-toggle.blade.php
+++ b/resources/views/forms/shield-toggle.blade.php
@@ -1,0 +1,157 @@
+@php
+    $offColor = $getOffColor() ?? 'gray';
+    $onColor = $getOnColor() ?? 'primary';
+    $statePath = $getStatePath();
+@endphp
+
+<x-dynamic-component
+    :component="$getFieldWrapperView()"
+    :field="$field"
+    :inline-label-vertical-alignment="\Filament\Support\Enums\VerticalAlignment::Center"
+>
+    @capture($content)
+        <button
+            wire:key="{{ $this->getId() }}"
+            x-data="{
+                state: $wire.{{ $applyStateBindingModifiers("\$entangle('{$statePath}')") }},
+                checkboxes: [],
+                checkboxLists: [],
+                toggleAllCheckboxes: function () {
+                    this.checkboxes.forEach(checkbox => {
+                        checkbox.checked = this.state;
+                    });
+                    this.updateStateBasedOnCheckboxes();
+                    this.checkboxLists.forEach(checkboxList => {
+                        Alpine.$data(checkboxList.parentNode).checkIfAllCheckboxesAreChecked();
+                    })
+                },
+
+                updateStateBasedOnCheckboxes: function () {
+                    this.state = this.checkboxes.every(checkbox => checkbox.checked );
+                },
+
+                init: function() {
+                    this.checkboxLists = Array.from(document.querySelectorAll('.fi-fo-checkbox-list'))
+                    this.checkboxes = Array.from(document.querySelectorAll('.fi-fo-checkbox-list-option-label input[type=\'checkbox\']'));
+                    this.checkboxes.forEach((checkbox) => {
+                        checkbox.addEventListener('change', () => {
+                            this.updateStateBasedOnCheckboxes();
+                        });
+                    });
+                }
+            }"
+            x-init="init()"
+            x-on:click="state = !state; toggleAllCheckboxes();"
+            x-bind:class="
+                state
+                    ? '{{
+                        match ($onColor) {
+                            'gray' => 'fi-color-gray bg-gray-200 dark:bg-gray-700',
+                            default => 'fi-color-custom bg-custom-600',
+                        }
+                    }}'
+                    : '{{
+                        match ($offColor) {
+                            'gray' => 'fi-color-gray bg-gray-200 dark:bg-gray-700',
+                            default => 'fi-color-custom bg-custom-600',
+                        }
+                    }}'
+            "
+            x-bind:style="
+                state
+                    ? '{{
+                        \Filament\Support\get_color_css_variables(
+                            $onColor,
+                            shades: [600],
+                            alias: 'forms::components.toggle.on',
+                        )
+                    }}'
+                    : '{{
+                        \Filament\Support\get_color_css_variables(
+                            $offColor,
+                            shades: [600],
+                            alias: 'forms::components.toggle.off',
+                        )
+                    }}'
+            "
+            {{
+                $attributes
+                    ->merge([
+                        'aria-checked' => 'false',
+                        'autofocus' => $isAutofocused(),
+                        'disabled' => $isDisabled(),
+                        'id' => $getId(),
+                        'role' => 'switch',
+                        'type' => 'button',
+                        'wire:loading.attr' => 'disabled',
+                        'wire:target' => $statePath,
+                    ], escape: false)
+                    ->merge($getExtraAttributes(), escape: false)
+                    ->merge($getExtraAlpineAttributes(), escape: false)
+                    ->class(['fi-fo-toggle relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent outline-none transition-colors duration-200 ease-in-out disabled:pointer-events-none disabled:opacity-70'])
+            }}
+        >
+            <span
+                class="relative inline-block w-5 h-5 transition duration-200 ease-in-out transform bg-white rounded-full shadow pointer-events-none ring-0"
+                x-bind:class="{
+                    'translate-x-5 rtl:-translate-x-5': state,
+                    'translate-x-0': ! state,
+                }"
+            >
+                <span
+                    class="absolute inset-0 flex items-center justify-center w-full h-full transition-opacity"
+                    aria-hidden="true"
+                    x-bind:class="{
+                        'opacity-0 ease-out duration-100': state,
+                        'opacity-100 ease-in duration-200': ! state,
+                    }"
+                >
+                    @if ($hasOffIcon())
+                        <x-filament::icon
+                            :icon="$getOffIcon()"
+                            @class([
+                                'fi-fo-toggle-off-icon h-3 w-3',
+                                match ($offColor) {
+                                    'gray' => 'text-gray-400 dark:text-gray-700',
+                                    default => 'text-custom-600',
+                                },
+                            ])
+                        />
+                    @endif
+                </span>
+
+                <span
+                    class="absolute inset-0 flex items-center justify-center w-full h-full transition-opacity"
+                    aria-hidden="true"
+                    x-bind:class="{
+                        'opacity-100 ease-in duration-200': state,
+                        'opacity-0 ease-out duration-100': ! state,
+                    }"
+                >
+                    @if ($hasOnIcon())
+                        <x-filament::icon
+                            :icon="$getOnIcon()"
+                            x-cloak="x-cloak"
+                            @class([
+                                'fi-fo-toggle-on-icon h-3 w-3',
+                                match ($onColor) {
+                                    'gray' => 'text-gray-400 dark:text-gray-700',
+                                    default => 'text-custom-600',
+                                },
+                            ])
+                        />
+                    @endif
+                </span>
+            </span>
+        </button>
+    @endcapture
+
+    @if ($isInline())
+        <x-slot name="labelPrefix">
+            {{ $content() }}
+        </x-slot>
+    @else
+        {{ $content() }}
+    @endif
+</x-dynamic-component>
+

--- a/resources/views/forms/shield-toggle.blade.php
+++ b/resources/views/forms/shield-toggle.blade.php
@@ -38,6 +38,9 @@
                             this.updateStateBasedOnCheckboxes();
                         });
                     });
+                    $nextTick(() => {
+                        this.updateStateBasedOnCheckboxes();
+                    });
                 }
             }"
             x-init="init()"

--- a/src/FilamentShieldServiceProvider.php
+++ b/src/FilamentShieldServiceProvider.php
@@ -15,6 +15,7 @@ class FilamentShieldServiceProvider extends PackageServiceProvider
             ->name('filament-shield')
             ->hasConfigFile()
             ->hasTranslations()
+            ->hasViews()
             ->hasCommands($this->getCommands());
     }
 

--- a/src/Forms/ShieldSelectAllToggle.php
+++ b/src/Forms/ShieldSelectAllToggle.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BezhanSalleh\FilamentShield\Forms;
+
+use Filament\Forms\Components\Toggle;
+
+class ShieldSelectAllToggle extends Toggle
+{
+    protected string $view = 'filament-shield::forms.shield-toggle';
+}

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -80,7 +80,7 @@ class RoleResource extends Resource implements HasShieldPermissions
                             ]),
                         static::getTabFormComponentForPage(),
                         static::getTabFormComponentForWidget(),
-                        static::getTabFormComponentForCustomPermissions()
+                        static::getTabFormComponentForCustomPermissions(),
                     ])
                     ->columnSpan('full'),
             ]);
@@ -352,15 +352,15 @@ class RoleResource extends Resource implements HasShieldPermissions
             ->label('')
             ->options(fn (): array => $options)
             ->searchable()
-            ->afterStateHydrated(fn (Component $component, string $operation, ?Model $record) =>
-                static::setPermissionStateForRecordPermissions(
+            ->afterStateHydrated(
+                fn (Component $component, string $operation, ?Model $record) => static::setPermissionStateForRecordPermissions(
                     component: $component,
                     operation: $operation,
                     permissions: $options,
                     record: $record
                 )
             )
-            ->dehydrated(fn ($state) => !blank($state))
+            ->dehydrated(fn ($state) => ! blank($state))
             ->bulkToggleable()
             ->gridDirection('row')
             ->columns(FilamentShieldPlugin::get()->getCheckboxListColumns())

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -55,16 +55,13 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     ->default(Utils::getFilamentAuthGuard())
                                     ->nullable()
                                     ->maxLength(255),
-                                Forms\Components\Toggle::make('select_all')
+                                \BezhanSalleh\FilamentShield\Forms\ShieldSelectAllToggle::make('select_all')
                                     ->onIcon('heroicon-s-shield-check')
                                     ->offIcon('heroicon-s-shield-exclamation')
                                     ->label(__('filament-shield::filament-shield.field.select_all.name'))
                                     ->helperText(fn (): HtmlString => new HtmlString(__('filament-shield::filament-shield.field.select_all.message')))
-                                    ->live()
-                                    ->afterStateUpdated(function ($livewire, Forms\Set $set, $state) {
-                                        static::toggleEntitiesViaSelectAll($livewire, $set, $state);
-                                    })
                                     ->dehydrated(fn ($state): bool => $state),
+
                             ])
                             ->columns([
                                 'sm' => 2,
@@ -90,7 +87,6 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     ->label('')
                                     ->options(fn (): array => static::getPageOptions())
                                     ->searchable()
-                                    ->live()
                                     ->afterStateHydrated(function (Component $component, $livewire, string $operation, ?Model $record, Forms\Set $set) {
                                         static::setPermissionStateForRecordPermissions(
                                             component: $component,
@@ -98,23 +94,8 @@ class RoleResource extends Resource implements HasShieldPermissions
                                             permissions: static::getPageOptions(),
                                             record: $record
                                         );
-                                        static::toggleSelectAllViaEntities($livewire, $set);
                                     })
-                                    ->afterStateUpdated(fn ($livewire, Forms\Set $set) => static::toggleSelectAllViaEntities($livewire, $set))
-                                    ->selectAllAction(fn (FormAction $action, Component $component, $livewire, Forms\Set $set) => static::bulkToggleableAction(
-                                        action: $action,
-                                        component: $component,
-                                        livewire: $livewire,
-                                        set: $set
-                                    ))
-                                    ->deselectAllAction(fn (FormAction $action, Component $component, $livewire, Forms\Set $set) => static::bulkToggleableAction(
-                                        action: $action,
-                                        component: $component,
-                                        livewire: $livewire,
-                                        set: $set,
-                                        resetState: true
-                                    ))
-                                    ->dehydrated(fn ($state) => blank($state) ? false : true)
+                                    ->dehydrated(fn ($state) => !blank($state))
                                     ->bulkToggleable()
                                     ->gridDirection('row')
                                     ->columns(FilamentShieldPlugin::get()->getCheckboxListColumns())
@@ -128,7 +109,6 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     ->label('')
                                     ->options(fn (): array => static::getWidgetOptions())
                                     ->searchable()
-                                    ->live()
                                     ->afterStateHydrated(function (Component $component, $livewire, string $operation, ?Model $record, Forms\Set $set) {
                                         static::setPermissionStateForRecordPermissions(
                                             component: $component,
@@ -136,24 +116,8 @@ class RoleResource extends Resource implements HasShieldPermissions
                                             permissions: static::getWidgetOptions(),
                                             record: $record
                                         );
-
-                                        static::toggleSelectAllViaEntities($livewire, $set);
                                     })
-                                    ->afterStateUpdated(fn ($livewire, Forms\Set $set) => static::toggleSelectAllViaEntities($livewire, $set))
-                                    ->selectAllAction(fn (FormAction $action, Component $component, $livewire, Forms\Set $set) => static::bulkToggleableAction(
-                                        action: $action,
-                                        component: $component,
-                                        livewire: $livewire,
-                                        set: $set
-                                    ))
-                                    ->deselectAllAction(fn (FormAction $action, Component $component, $livewire, Forms\Set $set) => static::bulkToggleableAction(
-                                        action: $action,
-                                        component: $component,
-                                        livewire: $livewire,
-                                        set: $set,
-                                        resetState: true
-                                    ))
-                                    ->dehydrated(fn ($state) => blank($state) ? false : true)
+                                    ->dehydrated(fn ($state) => !blank($state))
                                     ->bulkToggleable()
                                     ->gridDirection('row')
                                     ->columns(FilamentShieldPlugin::get()->getCheckboxListColumns())
@@ -167,7 +131,6 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     ->label('')
                                     ->options(fn (): array => static::getCustomPermissionOptions())
                                     ->searchable()
-                                    ->live()
                                     ->afterStateHydrated(function (Component $component, $livewire, string $operation, ?Model $record, Forms\Set $set) {
                                         static::setPermissionStateForRecordPermissions(
                                             component: $component,
@@ -175,23 +138,8 @@ class RoleResource extends Resource implements HasShieldPermissions
                                             permissions: static::getCustomPermissionOptions(),
                                             record: $record
                                         );
-                                        static::toggleSelectAllViaEntities($livewire, $set);
                                     })
-                                    ->afterStateUpdated(fn ($livewire, Forms\Set $set) => static::toggleSelectAllViaEntities($livewire, $set))
-                                    ->selectAllAction(fn (FormAction $action, Component $component, $livewire, Forms\Set $set) => static::bulkToggleableAction(
-                                        action: $action,
-                                        component: $component,
-                                        livewire: $livewire,
-                                        set: $set
-                                    ))
-                                    ->deselectAllAction(fn (FormAction $action, Component $component, $livewire, Forms\Set $set) => static::bulkToggleableAction(
-                                        action: $action,
-                                        component: $component,
-                                        livewire: $livewire,
-                                        set: $set,
-                                        resetState: true
-                                    ))
-                                    ->dehydrated(fn ($state) => blank($state) ? false : true)
+                                    ->dehydrated(fn ($state) => !blank($state))
                                     ->bulkToggleable()
                                     ->gridDirection('row')
                                     ->columns(FilamentShieldPlugin::get()->getCheckboxListColumns())
@@ -328,7 +276,10 @@ class RoleResource extends Resource implements HasShieldPermissions
                     ->description(fn () => new HtmlString('<span style="word-break: break-word;">' . Utils::showModelPath($entity['fqcn']) . '</span>'))
                     ->compact()
                     ->schema([
-                        static::getCheckBoxListComponentForResource($entity),
+                        static::getCheckBoxListComponentForResource($entity)
+                            ->extraAttributes([
+                                'name' => 'yellow'
+                            ]),
                     ])
                     ->columnSpan(FilamentShieldPlugin::get()->getSectionColumnSpan())
                     ->collapsible();
@@ -369,42 +320,6 @@ class RoleResource extends Resource implements HasShieldPermissions
                         ->toArray()
                 );
             }
-        }
-    }
-
-    public static function toggleEntitiesViaSelectAll($livewire, Forms\Set $set, bool $state): void
-    {
-        $entitiesComponents = collect($livewire->form->getFlatComponents())
-            ->filter(fn (Component $component) => $component instanceof Forms\Components\CheckboxList);
-
-        if ($state) {
-            $entitiesComponents
-                ->each(
-                    function (Forms\Components\CheckboxList $component) use ($set) {
-                        $set($component->getName(), array_keys($component->getOptions()));
-                    }
-                );
-        } else {
-            $entitiesComponents
-                ->each(fn (Forms\Components\CheckboxList $component) => $component->state([]));
-        }
-    }
-
-    public static function toggleSelectAllViaEntities($livewire, Forms\Set $set): void
-    {
-        $entitiesStates = collect($livewire->form->getFlatComponents())
-            ->reduce(function ($counts, $component) {
-                if ($component instanceof Forms\Components\CheckboxList) {
-                    $counts[$component->getName()] = count(array_keys($component->getOptions())) == count(collect($component->getState())->values()->unique()->toArray());
-                }
-
-                return $counts;
-            }, collect())
-            ->values();
-        if ($entitiesStates->containsStrict(false)) {
-            $set('select_all', false);
-        } else {
-            $set('select_all', true);
         }
     }
 
@@ -452,17 +367,6 @@ class RoleResource extends Resource implements HasShieldPermissions
         return static::$permissionsCollection->whereNotIn('name', $entitiesPermissions)->pluck('name');
     }
 
-    public static function bulkToggleableAction(FormAction $action, Component $component, $livewire, Forms\Set $set, bool $resetState = false): void
-    {
-        $action
-            ->livewireClickHandlerEnabled(true)
-            ->action(function () use ($component, $livewire, $set, $resetState) {
-                /** @phpstan-ignore-next-line */
-                $component->state($resetState ? [] : array_keys($component->getOptions()));
-                static::toggleSelectAllViaEntities($livewire, $set);
-            });
-    }
-
     public static function getCheckBoxListComponentForResource(array $entity): Component
     {
         $permissionsArray = static::getResourcePermissionOptions($entity);
@@ -470,7 +374,6 @@ class RoleResource extends Resource implements HasShieldPermissions
         return Forms\Components\CheckboxList::make($entity['resource'])
             ->label('')
             ->options(fn (): array => $permissionsArray)
-            ->live()
             ->afterStateHydrated(function (Component $component, $livewire, string $operation, ?Model $record, Forms\Set $set) use ($permissionsArray) {
                 static::setPermissionStateForRecordPermissions(
                     component: $component,
@@ -478,12 +381,7 @@ class RoleResource extends Resource implements HasShieldPermissions
                     permissions: $permissionsArray,
                     record: $record
                 );
-
-                static::toggleSelectAllViaEntities($livewire, $set);
             })
-            ->afterStateUpdated(fn ($livewire, Forms\Set $set) => static::toggleSelectAllViaEntities($livewire, $set))
-            ->selectAllAction(fn (FormAction $action, Component $component, $livewire, Forms\Set $set) => static::bulkToggleableAction($action, $component, $livewire, $set))
-            ->deselectAllAction(fn (FormAction $action, Component $component, $livewire, Forms\Set $set) => static::bulkToggleableAction($action, $component, $livewire, $set, true))
             ->dehydrated(fn ($state) => ! blank($state))
             ->bulkToggleable()
             ->gridDirection('row')


### PR DESCRIPTION
To make permission selection(single or all) more perfromant a new custom `ShieldSelectAllToggle` components has been introduced. This helps with handling all the state changes in frontend without triggering livewire update on every state change.
Due to `CheckboxList`'s `afterStateUpdated()` bug fix in v3.2 a number of refactors has been applied which removed a lot of unnecessary workarounds. Therefore, the new filament dep requirements is v3.2.