### PR TITLE
Update Utils.php showModelPath()

### DIFF
--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -191,6 +191,24 @@ class Utils
 
     public static function showModelPath(string $resourceFQCN): string
     {
+        $reflectionClass = new \ReflectionClass($resourceFQCN);
+        try {
+            $reflectionClass->getProperty('model');
+            if (!$reflectionClass->getStaticPropertyValue('model')) {
+                throw new \ErrorException();
+            }
+        } catch (\Exception $e) {
+            try {
+                $reflectionClass->getMethod('getModel');
+                $resourceFQCN = $resourceFQCN::getModel();
+            } catch (\Exception $e) {
+                try {
+                    $reflectionClass->getMethod('setModel');
+                    $resourceFQCN = $resourceFQCN::setModel();
+                } catch (\Exception $e) {
+                }
+            }
+        }
         return config('filament-shield.shield_resource.show_model_path', true)
             ? get_class(new ($resourceFQCN::getModel())())
             : '';


### PR DESCRIPTION
ShowModelPath() checks for static $model ModelClass or the value(s) of getModel() / setModel() via ReflectionClass

see issue: https://github.com/bezhanSalleh/filament-shield/issues/323