### PR TITLE
Add option to shield:seeder command to only generate direct permissions

### DIFF
--- a/src/Commands/MakeShieldSeederCommand.php
+++ b/src/Commands/MakeShieldSeederCommand.php
@@ -18,6 +18,7 @@ class MakeShieldSeederCommand extends Command
      */
     public $signature = 'shield:seeder
         {--generate : Generates permissions for all entities as configured }
+        {--option= : Generate only permissions via roles or direct permissions (<fg=green;options=bold>permissions_via_roles,direct_permissions</>)}
         {--F|force : Override if the seeder already exists }
     ';
 
@@ -52,7 +53,9 @@ class MakeShieldSeederCommand extends Command
         $permissionsViaRoles = collect();
         $directPermissions = collect();
 
-        if (Utils::getRoleModel()::exists()) {
+        $option = $this->option('option');
+
+        if ((Utils::getRoleModel()::exists() && is_null($option)) || $option === 'permissions_via_roles') {
             $permissionsViaRoles = collect(Utils::getRoleModel()::with('permissions')->get())
                 ->map(function ($role) use ($directPermissionNames) {
                     $rolePermissions = $role->permissions
@@ -69,7 +72,7 @@ class MakeShieldSeederCommand extends Command
                 });
         }
 
-        if (Utils::getPermissionModel()::exists()) {
+        if ((Utils::getPermissionModel()::exists() && is_null($option)) || $option === 'direct_permissions') {
             $directPermissions = collect(Utils::getPermissionModel()::get())
                 ->filter(fn ($permission) => ! in_array($permission->name, $directPermissionNames->unique()->flatten()->all()))
                 ->map(fn ($permission) => [


### PR DESCRIPTION
This PR will add an `--option` option to the shield:seeder command.
This option supports two choices:
1. `permissions_via_roles`: Only generate the seeder with permissions via roles
2. `direct_permissions`: Only generate the seeder with direct permissions

Will fix #309 