### PR TITLE
Can print permissions without pretty label

### DIFF
--- a/src/Concerns/CanCustomizeLabels.php
+++ b/src/Concerns/CanCustomizeLabels.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BezhanSalleh\FilamentShield\Concerns;
+
+trait CanCustomizeLabels
+{
+    protected bool $prettyResourcePermissionsLabel = true;
+    protected bool $prettyPagePermissionsLabel = true;
+    protected bool $prettyWidgetPermissionsLabel = true;
+    protected bool $prettyCustomPermissionsLabel = true;
+
+    public function prettyResourcePermissionsLabel(bool $bool = true): static
+    {
+        $this->prettyResourcePermissionsLabel = $bool;
+
+        return $this;
+    }
+
+    public function isPrettyResourcePermissionsLabel(): bool
+    {
+        return  $this->prettyResourcePermissionsLabel;
+    }
+
+    public function prettyPagePermissionsLabel(bool $bool = true): static
+    {
+        $this->prettyPagePermissionsLabel = $bool;
+
+        return $this;
+    }
+
+    public function isPrettyPagePermissionsLabel(): bool
+    {
+        return  $this->prettyPagePermissionsLabel;
+    }
+
+    public function prettyWidgetPermissionsLabel(bool $bool = true): static
+    {
+        $this->prettyWidgetPermissionsLabel = $bool;
+
+        return $this;
+    }
+
+    public function isPrettyWidgetPermissionsLabel(): bool
+    {
+        return  $this->prettyWidgetPermissionsLabel;
+    }
+
+    public function prettyCustomPermissionsLabel(bool $bool = true): static
+    {
+        $this->prettyCustomPermissionsLabel = $bool;
+
+        return $this;
+    }
+
+    public function isPrettyCustomPermissionsLabel(): bool
+    {
+        return  $this->prettyCustomPermissionsLabel;
+    }
+
+}

--- a/src/FilamentShieldPlugin.php
+++ b/src/FilamentShieldPlugin.php
@@ -11,6 +11,7 @@ use Filament\Panel;
 class FilamentShieldPlugin implements Plugin
 {
     use Concerns\CanCustomizeColumns;
+    use Concerns\CanCustomizeLabels;
 
     public static function make(): static
     {

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -231,7 +231,7 @@ class RoleResource extends Resource implements HasShieldPermissions
     {
         return collect(Utils::getResourcePermissionPrefixes($entity['fqcn']))
             ->flatMap(fn ($permission) => [
-                $permission . '_' . $entity['resource'] => FilamentShield::getLocalizedResourcePermissionLabel($permission),
+                $permission . '_' . $entity['resource'] => FilamentShieldPlugin::get()->isPrettyResourcePermissionsLabel() ? FilamentShield::getLocalizedResourcePermissionLabel($permission) : $permission,
             ])
             ->toArray();
     }
@@ -260,7 +260,7 @@ class RoleResource extends Resource implements HasShieldPermissions
     {
         return collect(FilamentShield::getPages())
             ->flatMap(fn ($page) => [
-                $page['permission'] => FilamentShield::getLocalizedPageLabel($page['class']),
+                $page['permission'] => FilamentShieldPlugin::get()->isPrettyPagePermissionsLabel() ? FilamentShield::getLocalizedPageLabel($page['class']) : $page['permission'],
             ])
             ->toArray();
     }
@@ -269,7 +269,7 @@ class RoleResource extends Resource implements HasShieldPermissions
     {
         return collect(FilamentShield::getWidgets())
             ->flatMap(fn ($widget) => [
-                $widget['permission'] => FilamentShield::getLocalizedWidgetLabel($widget['class']),
+                $widget['permission'] => FilamentShieldPlugin::get()->isPrettyWidgetPermissionsLabel() ? FilamentShield::getLocalizedWidgetLabel($widget['class']) : $widget['permission'],
             ])
             ->toArray();
     }
@@ -278,7 +278,7 @@ class RoleResource extends Resource implements HasShieldPermissions
     {
         return collect(static::getCustomEntities())
             ->flatMap(fn ($customPermission) => [
-                $customPermission => str($customPermission)->headline()->toString(),
+                $customPermission => FilamentShieldPlugin::get()->isPrettyCustomPermissionsLabel() ? str($customPermission)->headline()->toString() : $customPermission,
             ])
             ->toArray();
     }


### PR DESCRIPTION
In some cases it is better to have the name of the permission and not the label.

I have prepared this trait to be able to disable the labels from the application provider, and for the permission name to appear.

By default the labels will be activated so that they do not affect users, but if desired, they can be deactivated with these functions.