### PR TITLE
Don't use hardcoded primary key name

### DIFF
--- a/src/Commands/MakeShieldSuperAdminCommand.php
+++ b/src/Commands/MakeShieldSuperAdminCommand.php
@@ -65,7 +65,7 @@ class MakeShieldSuperAdminCommand extends Command
                 ['ID', 'Name', 'Email', 'Roles'],
                 static::getUserModel()::with('roles')->get()->map(function (Authenticatable $user) {
                     return [
-                        'id' => $user->getAttribute('id'),
+                        'id' => $user->getKey(),
                         'name' => $user->getAttribute('name'),
                         'email' => $user->getAttribute('email'),
                         /** @phpstan-ignore-next-line */


### PR DESCRIPTION
Not all User models use 'id' as the primary key. For example, mine is 'uuid'. 

Using `->getKey()` automatically gets the primary key value for us to use in the options table.