### PR TITLE
Overide canAccess that will point to canView

### DIFF
--- a/src/Traits/HasPageShield.php
+++ b/src/Traits/HasPageShield.php
@@ -71,4 +71,9 @@ trait HasPageShield
     {
         return static::canView() && parent::shouldRegisterNavigation();
     }
+
+    public static function canAccess(): bool
+    {
+        return static::canView();
+    }
 }


### PR DESCRIPTION
In case you are use a Cluster, the item will show in the navigation even though all the pages inside are without access, clicking on the item and navigating will bring an error.

Since the item is hidden by the canAccess method check I added it, now it will work smoothly.

T.Y