### PR TITLE
Removed unused model_variable in the policy stubs

### DIFF
--- a/stubs/DefaultPolicy.stub
+++ b/stubs/DefaultPolicy.stub
@@ -21,7 +21,7 @@ class {{ modelPolicy }}
     /**
      * Determine whether the {{ auth_model_variable }} can view the model.
      */
-    public function view({{ auth_model_name }} ${{ auth_model_variable }}, {{ model_name }} ${{ model_variable }}): bool
+    public function view({{ auth_model_name }} ${{ auth_model_variable }}): bool
     {
         return ${{ auth_model_variable }}->can('{{ View }}');
     }
@@ -37,7 +37,7 @@ class {{ modelPolicy }}
     /**
      * Determine whether the {{ auth_model_variable }} can update the model.
      */
-    public function update({{ auth_model_name }} ${{ auth_model_variable }}, {{ model_name }} ${{ model_variable }}): bool
+    public function update({{ auth_model_name }} ${{ auth_model_variable }}): bool
     {
         return ${{ auth_model_variable }}->can('{{ Update }}');
     }
@@ -45,7 +45,7 @@ class {{ modelPolicy }}
     /**
      * Determine whether the {{ auth_model_variable }} can delete the model.
      */
-    public function delete({{ auth_model_name }} ${{ auth_model_variable }}, {{ model_name }} ${{ model_variable }}): bool
+    public function delete({{ auth_model_name }} ${{ auth_model_variable }}): bool
     {
         return ${{ auth_model_variable }}->can('{{ Delete }}');
     }
@@ -61,7 +61,7 @@ class {{ modelPolicy }}
     /**
      * Determine whether the {{ auth_model_variable }} can permanently delete.
      */
-    public function forceDelete({{ auth_model_name }} ${{ auth_model_variable }}, {{ model_name }} ${{ model_variable }}): bool
+    public function forceDelete({{ auth_model_name }} ${{ auth_model_variable }}): bool
     {
         return ${{ auth_model_variable }}->can('{{ ForceDelete }}');
     }
@@ -77,7 +77,7 @@ class {{ modelPolicy }}
     /**
      * Determine whether the {{ auth_model_variable }} can restore.
      */
-    public function restore({{ auth_model_name }} ${{ auth_model_variable }}, {{ model_name }} ${{ model_variable }}): bool
+    public function restore({{ auth_model_name }} ${{ auth_model_variable }}): bool
     {
         return ${{ auth_model_variable }}->can('{{ Restore }}');
     }
@@ -93,7 +93,7 @@ class {{ modelPolicy }}
     /**
      * Determine whether the {{ auth_model_variable }} can replicate.
      */
-    public function replicate({{ auth_model_name }} ${{ auth_model_variable }}, {{ model_name }} ${{ model_variable }}): bool
+    public function replicate({{ auth_model_name }} ${{ auth_model_variable }}): bool
     {
         return ${{ auth_model_variable }}->can('{{ Replicate }}');
     }


### PR DESCRIPTION
I got an error when using AnyResource::can('view')

`Too few arguments to function App\Policies\AnyPolicy::view(), 1 passed in /var/www/html/vendor/laravel/framework/src/Illuminate/Auth/Access/Gate.php on line 811 and exactly 2 expected`

It needs a second parameter which isn't used in the methods.
`    
public function view(User $user, Model $model): bool
    {
        return $user->can('view_model');
    }
`

I removed the second parameter from the stub files to fix the issue.