### PR TITLE
Fix shouldRegisterNavigation

### DIFF
--- a/src/Traits/HasPageShield.php
+++ b/src/Traits/HasPageShield.php
@@ -64,7 +64,7 @@ trait HasPageShield
 
     public static function shouldRegisterNavigation(array $parameters = []): bool
     {
-        return static::canView() && parent::shouldRegisterNavigation();
+        return static::canAccess() && parent::shouldRegisterNavigation();
     }
 
     public static function canAccess(): bool

--- a/src/Traits/HasPageShield.php
+++ b/src/Traits/HasPageShield.php
@@ -62,9 +62,9 @@ trait HasPageShield
             ->toString();
     }
 
-    public static function shouldRegisterNavigation(): bool
+    public static function shouldRegisterNavigation(array $parameters = []): bool
     {
-        return static::canAccess() && parent::shouldRegisterNavigation();
+        return static::canView() && parent::shouldRegisterNavigation();
     }
 
     public static function canAccess(): bool


### PR DESCRIPTION
This patch is to fix an issue which prevents composer from installing.

There was an existing patch #249 - however this could not apply to the latest version (currently 3.2.5).

So I created this.