### PR TITLE
Allow json translation from project lang for widget name

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -301,10 +301,10 @@ class FilamentShield
         return match (true) {
             $widgetInstance instanceof TableWidget => (string) invade($widgetInstance)->makeTable()->getHeading(),
             ! ($widgetInstance instanceof TableWidget) && $widgetInstance instanceof Widget && method_exists($widgetInstance, 'getHeading') => (string) invade($widgetInstance)->getHeading(),
-            default => str($widget)
+            default => __(str($widget)
                 ->afterLast('\\')
                 ->headline()
-                ->toString(),
+                ->toString()),
         };
     }
 


### PR DESCRIPTION
Allow json translation from project lang for widget name, the modification in FilamentShield class only but phpstorm autoreformat code in other files, if you do not liked i will reverted.