### PR TITLE
Enhance RoleResource Table with Configurable Guard Name Grouping

### DIFF
--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -11,6 +11,7 @@ return [
         'show_model_path' => true,
         'is_scoped_to_tenant' => true,
         'cluster' => null,
+        'table_group_by_guard_name' => true,
     ],
 
     'auth_provider_model' => [

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -82,6 +82,7 @@ class RoleResource extends Resource implements HasShieldPermissions
     public static function table(Table $table): Table
     {
         return $table
+            ->defaultGroup(config('filament-shield.shield_resource.table_group_by_guard_name') ? 'guard_name' : null)
             ->columns([
                 Tables\Columns\TextColumn::make('name')
                     ->badge()


### PR DESCRIPTION

## Description
This commit introduces a feature that allows for the grouping of multiple `guard_name` entries within the `RoleResource` table, improving usability and clarity when managing roles associated with various guards. By enabling the grouping of `guard_name` entries, users can more easily navigate and organize the roles assigned to different guards, resulting in a more logical and visually appealing interface.

To facilitate this enhancement, a new configuration option has been added:

```php
'table_group_by_guard_name' => true // Set to true or false
