### PR TITLE
fix: Add error handling for team options when teams are not used

### DIFF
--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -60,7 +60,7 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     ->placeholder(__('filament-shield::filament-shield.field.team.placeholder'))
                                     /** @phpstan-ignore-next-line */
                                     ->default([Filament::getTenant()?->id])
-                                    ->options(fn (): Arrayable => Utils::getTenantModel()::pluck('name', 'id'))
+                                    ->options(fn (): Arrayable => Utils::getTenantModel() ? Utils::getTenantModel()::pluck('name', 'id') : collect())
                                     ->hidden(fn (): bool => ! static::shield()->isCentralApp() && Filament::hasTenancy())
                                     ->dehydrated(fn (): bool => ! static::shield()->isCentralApp() && Filament::hasTenancy()),
 


### PR DESCRIPTION
Thank you for providing the fixes in release v3.3.2

This PR addresses the issue where `Utils::getTenantModel()` could return `null`, leading to the "Class name must be a valid object or a string" error page when trying to edit roles. The solution includes a null check, ensuring that if getTenantModel() returns null, the code safely returns an empty collection.