### PR TITLE
Permission label translation

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -189,7 +189,7 @@ class FilamentShield
     {
         return Lang::has("filament-shield::filament-shield.resource_permission_prefixes_labels.$permission", app()->getLocale())
             ? __("filament-shield::filament-shield.resource_permission_prefixes_labels.$permission")
-            : Str::of($permission)->headline();
+            : __(Str::of($permission)->headline()->toString());
     }
 
     /**


### PR DESCRIPTION
Allow permission label to be translated directly from laravel json file translation.