### PR TITLE
Remove double-pluralization from `getAllResourcePermissions`

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -349,7 +349,6 @@ class FilamentShield
                             ? str(static::getLocalizedResourcePermissionLabel($permission))
                                 ->prepend(
                                     str($resourceEntity['fqcn']::getPluralModelLabel())
-                                        ->plural()
                                         ->title()
                                         ->append(' - ')
                                         ->toString()


### PR DESCRIPTION
# Problem

[`getAllResourcePermissions()`](https://github.com/bezhanSalleh/filament-shield/blob/3.x/src/FilamentShield.php#L349) is currently running the already pluralized [`Resource::getPluralModelLabel()`](https://github.com/filamentphp/filament/blob/3.x/packages/panels/src/Resources/Resource.php#L521) through `->plural()` again which causes issues in non-english languages. See the german example below.

```php
->prepend(
    str($resourceEntity['fqcn']::getPluralModelLabel())
        ->plural()
        ->title()
        ->append(' - ')
        ->toString()
```

# Example

German example:
| Singular| Plural| Expected output| Actual output|
|--------|--------|--------|--------|
| Kunde| Kunden | Kunden ✅| Kundens ❌|
| Lieferant| Lieferanten| Lieferanten ✅ | Lieferantens ❌|

English example:
| Singular| Plural| Expected output| Actual output|
|--------|--------|--------|--------|
| Customer | Customers | Customers  ✅| Customers ✅|
| User| Users| Users ✅| Users ✅|

# Fix
The fix seems to be straight forward since Filament [internally](https://github.com/filamentphp/filament/blob/3.x/packages/panels/src/Resources/Resource.php#L521) already properly pluralizes the `getPluralModelLabel()`

```diff
  ->prepend(
      str($resourceEntity['fqcn']::getPluralModelLabel())
-         ->plural()
          ->title()
          ->append(' - ')
          ->toString()
```
# Reference
## Before 

![Screenshot 2024-12-11 230507](https://github.com/user-attachments/assets/ad5ca483-dcb4-427a-b9e3-d3f3bc9f1d1b)

![Screenshot 2024-12-11 230604](https://github.com/user-attachments/assets/66012245-ec99-49b1-a29f-a1ba54a82b8f)

## After 

![Screenshot 2024-12-11 230431](https://github.com/user-attachments/assets/155d2f67-78f7-4896-b624-3370bf179c79)

![Screenshot 2024-12-11 230622](https://github.com/user-attachments/assets/22e38035-67fe-4303-aa98-ff4a0489566d)
