### PR TITLE
[Fix] Handles Widget Permission Labels through `$heading`

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -311,14 +311,19 @@ class FilamentShield
 
         return match (true) {
             $widgetInstance instanceof TableWidget => (string) invade($widgetInstance)->makeTable()->getHeading(),
-            ! ($widgetInstance instanceof TableWidget) && $widgetInstance instanceof Widget && method_exists($widgetInstance, 'getHeading') => (string) invade($widgetInstance)->getHeading(),
+            self::hasValidHeading($widgetInstance) => (string) invade($widgetInstance)->getHeading(),
             default => str($widget)
                 ->afterLast('\\')
                 ->headline()
                 ->toString(),
         };
     }
-
+    private static function hasValidHeading($widgetInstance): bool
+    {
+        return $widgetInstance instanceof Widget 
+            && method_exists($widgetInstance, 'getHeading') 
+            && $widgetInstance->getHeading() !== null;
+    }
     protected function getDefaultPermissionIdentifier(string $resource): string
     {
         return Str::of($resource)


### PR DESCRIPTION
Fix for Issue #471:

	•	Added a check to ensure that the getHeading method returns a non-null value before using it.
	•	Removed redundant check for TableWidget in the heading validation logic, as it’s already handled in the existing conditions.
This should address the issue with heading retrieval in widgets