### PR TITLE
fixes #481

### DIFF
--- a/src/Traits/HasPageShield.php
+++ b/src/Traits/HasPageShield.php
@@ -63,6 +63,6 @@ trait HasPageShield
 
     public static function canAccess(array $parameters = []): bool
     {
-        return Filament::auth()->user()->can(static::getPermissionName());
+        return Filament::auth()->user()?->can(static::getPermissionName());
     }
 }

--- a/src/Traits/HasPageShield.php
+++ b/src/Traits/HasPageShield.php
@@ -63,6 +63,6 @@ trait HasPageShield
 
     public static function canAccess(array $parameters = []): bool
     {
-        return Filament::auth()->user()?->can(static::getPermissionName());
+        return Filament::auth()->user()?->can(static::getPermissionName()) ?? false;
     }
 }

--- a/src/Traits/HasWidgetShield.php
+++ b/src/Traits/HasWidgetShield.php
@@ -10,7 +10,7 @@ trait HasWidgetShield
 {
     public static function canView(): bool
     {
-        return Filament::auth()->user()->can(static::getPermissionName()) || Filament::auth()->user()->hasRole(Utils::getSuperAdminName());
+        return Filament::auth()->user()?->can(static::getPermissionName()) || Filament::auth()->user()?->hasRole(Utils::getSuperAdminName());
     }
 
     protected static function getPermissionName(): string


### PR DESCRIPTION
fixes #481 prevent exception by indicating that `user()` can be null