### PR TITLE
BUGFIX: Missing Widget Titles -- Add additional null check for getHeading() within getLocalizedWidgetLabel()

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -311,7 +311,7 @@ class FilamentShield
 
         return match (true) {
             $widgetInstance instanceof TableWidget => (string) invade($widgetInstance)->makeTable()->getHeading(),
-            ! ($widgetInstance instanceof TableWidget) && $widgetInstance instanceof Widget && method_exists($widgetInstance, 'getHeading') => (string) invade($widgetInstance)->getHeading(),
+            ! ($widgetInstance instanceof TableWidget) && $widgetInstance instanceof Widget && method_exists($widgetInstance, 'getHeading') && invade($widgetInstance)->getHeading() !== null => (string) invade($widgetInstance)->getHeading(),
             default => str($widget)
                 ->afterLast('\\')
                 ->headline()


### PR DESCRIPTION
This null check is necessary because Filament\Widgets\StatsOverviewWidget.php always has a base getHeading() method.

This causes the "default" branch within the match statement to not execute, resulting in missing Widget titles. 

![image](https://github.com/user-attachments/assets/f34507ab-ae0e-495e-b821-748544f1b060)


See https://github.com/bezhanSalleh/filament-shield/issues/493

This currently works as-is for the table widgets because it uses a different method name --> getTableHeading() and does not have a getHeading() method.

Adding this null check should give us the expected behavior.

![image](https://github.com/user-attachments/assets/46b2b603-748d-4fa1-b0c8-64a7e1b7e1ef)
