### PR TITLE
wire up column config for resource

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -323,7 +323,7 @@ class FilamentShield
     {
         return $widgetInstance instanceof Widget
             && method_exists($widgetInstance, 'getHeading')
-            && $widgetInstance->getHeading() !== null;
+            && filled(invade($widgetInstance)->getHeading());
     }
 
     protected function getDefaultPermissionIdentifier(string $resource): string

--- a/src/Traits/HasShieldFormComponents.php
+++ b/src/Traits/HasShieldFormComponents.php
@@ -12,8 +12,6 @@ use Filament\Forms\Components\Component;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 
-use function Laravel\Prompts\search;
-
 trait HasShieldFormComponents
 {
     public static function getShieldFormComponents(): Component
@@ -183,7 +181,7 @@ trait HasShieldFormComponents
                 static::getCheckboxListFormComponent(
                     name: 'widgets_tab',
                     options: $options,
-                )
+                ),
             ]);
     }
 
@@ -200,7 +198,7 @@ trait HasShieldFormComponents
                 static::getCheckboxListFormComponent(
                     name: 'custom_permissions',
                     options: $options,
-                )
+                ),
             ]);
     }
 
@@ -217,11 +215,11 @@ trait HasShieldFormComponents
                 static::getCheckboxListFormComponent(
                     name: 'resources_tab',
                     options: $options,
-                )
+                ),
             ]);
     }
 
-    public static function getCheckboxListFormComponent(string $name, array $options, bool $searchable = true, array|int|string|null $columns = null, array|int|string|null $columnSpan = null): Component
+    public static function getCheckboxListFormComponent(string $name, array $options, bool $searchable = true, array | int | string | null $columns = null, array | int | string | null $columnSpan = null): Component
     {
         return Forms\Components\CheckboxList::make($name)
             ->label('')

--- a/src/Traits/HasShieldFormComponents.php
+++ b/src/Traits/HasShieldFormComponents.php
@@ -12,6 +12,8 @@ use Filament\Forms\Components\Component;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 
+use function Laravel\Prompts\search;
+
 trait HasShieldFormComponents
 {
     public static function getShieldFormComponents(): Component
@@ -142,7 +144,13 @@ trait HasShieldFormComponents
     {
         $permissionsArray = static::getResourcePermissionOptions($entity);
 
-        return static::getCheckboxListFormComponent($entity['resource'], $permissionsArray, false);
+        return static::getCheckboxListFormComponent(
+            name: $entity['resource'],
+            options: $permissionsArray,
+            columns: static::shield()->getResourceCheckboxListColumns(),
+            columnSpan: static::shield()->getResourceCheckboxListColumnSpan(),
+            searchable: false
+        );
     }
 
     public static function getTabFormComponentForPage(): Component
@@ -155,7 +163,10 @@ trait HasShieldFormComponents
             ->visible(fn (): bool => (bool) Utils::isPageEntityEnabled() && $count > 0)
             ->badge($count)
             ->schema([
-                static::getCheckboxListFormComponent('pages_tab', $options),
+                static::getCheckboxListFormComponent(
+                    name: 'pages_tab',
+                    options: $options,
+                ),
             ]);
     }
 
@@ -169,7 +180,10 @@ trait HasShieldFormComponents
             ->visible(fn (): bool => (bool) Utils::isWidgetEntityEnabled() && $count > 0)
             ->badge($count)
             ->schema([
-                static::getCheckboxListFormComponent('widgets_tab', $options),
+                static::getCheckboxListFormComponent(
+                    name: 'widgets_tab',
+                    options: $options,
+                )
             ]);
     }
 
@@ -183,7 +197,10 @@ trait HasShieldFormComponents
             ->visible(fn (): bool => (bool) Utils::isCustomPermissionEntityEnabled() && $count > 0)
             ->badge($count)
             ->schema([
-                static::getCheckboxListFormComponent('custom_permissions', $options),
+                static::getCheckboxListFormComponent(
+                    name: 'custom_permissions',
+                    options: $options,
+                )
             ]);
     }
 
@@ -197,11 +214,14 @@ trait HasShieldFormComponents
             ->visible(fn (): bool => (bool) Utils::isResourceEntityEnabled() && $count > 0)
             ->badge($count)
             ->schema([
-                static::getCheckboxListFormComponent('resources_tab', $options),
+                static::getCheckboxListFormComponent(
+                    name: 'resources_tab',
+                    options: $options,
+                )
             ]);
     }
 
-    public static function getCheckboxListFormComponent(string $name, array $options, bool $searchable = true): Component
+    public static function getCheckboxListFormComponent(string $name, array $options, bool $searchable = true, array|int|string|null $columns = null, array|int|string|null $columnSpan = null): Component
     {
         return Forms\Components\CheckboxList::make($name)
             ->label('')
@@ -218,8 +238,8 @@ trait HasShieldFormComponents
             ->dehydrated(fn ($state) => ! blank($state))
             ->bulkToggleable()
             ->gridDirection('row')
-            ->columns(static::shield()->getCheckboxListColumns())
-            ->columnSpan(static::shield()->getCheckboxListColumnSpan());
+            ->columns($columns ?? static::shield()->getCheckboxListColumns())
+            ->columnSpan($columnSpan ?? static::shield()->getCheckboxListColumnSpan());
     }
 
     public static function shield(): FilamentShieldPlugin


### PR DESCRIPTION
this PR wires up the column and column span config for resources's checkbox when resource isn't simple.
this will allow to controll the checkbox's shown for permissions in the resources' tab separately from the other tabs column and column span config. previously the following two options were available but not wired-up.
```
->resourceCheckboxListColumns()
->resourceCheckboxListColumnSpan()
```
For checkboxes of other tabs and when resource is simple
```
->checkboxListColumns()
->checkboxListColumnSpan()
```
resolves #476 