### PR TITLE
[bug] Add optional Tenant to Role name unique rule

### DIFF
--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -45,7 +45,14 @@ class RoleResource extends Resource implements HasShieldPermissions
                             ->schema([
                                 Forms\Components\TextInput::make('name')
                                     ->label(__('filament-shield::filament-shield.field.name'))
-                                    ->unique(ignoreRecord: true)
+                                    ->unique(
+                                        ignoreRecord: true,
+                                        modifyRuleUsing: function($rule){
+                                            if( ! Utils::isTenancyEnabled() )
+                                                return $rule ;
+                                            return $rule->where(Utils::getTenantModelForeignKey(), Filament::getTenant()?->id);
+                                        })
+                                    )
                                     ->required()
                                     ->maxLength(255),
 


### PR DESCRIPTION
Hi.

When Tenant is enable, the unique role name have to be unique in the tenant.

So my proposition is to add a modifyRuleUsing closure to add a where clause when tenant is enabled.

Regards.