### PR TITLE
refactor: Use dynamic policy namespace for RolePolicy registration

### DIFF
--- a/src/FilamentShieldServiceProvider.php
+++ b/src/FilamentShieldServiceProvider.php
@@ -47,7 +47,7 @@ class FilamentShieldServiceProvider extends PackageServiceProvider
         }
 
         if (Utils::isRolePolicyRegistered()) {
-            Gate::policy(Utils::getRoleModel(), 'App\Policies\RolePolicy');
+            Gate::policy(Utils::getRoleModel(), 'App\\' . Utils::getPolicyNamespace() . '\\RolePolicy');
         }
     }
 


### PR DESCRIPTION
Updated the RolePolicy registration in FilamentShieldServiceProvider.php to use the dynamic namespace from `Utils::getPolicyNamespace()`. This change allows users to move their policies directory without breaking the RolePolicy registration, making the codebase more flexible and consistent.

Without this change, if someone moves their policies, they must also move the RolePolicy, otherwise it won't be registered.