### PR TITLE
add feature: copy role permissions from anothor role when create or edit role permission

### DIFF
--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -10,12 +10,15 @@ use BezhanSalleh\FilamentShield\Traits\HasShieldFormComponents;
 use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Forms\Set;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
 
 class RoleResource extends Resource implements HasShieldPermissions
 {
@@ -55,6 +58,8 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     ->nullable()
                                     ->maxLength(255),
 
+                                static::getCopyRoleSelectComponent(),
+
                                 Forms\Components\Select::make(config('permission.column_names.team_foreign_key'))
                                     ->label(__('filament-shield::filament-shield.field.team'))
                                     ->placeholder(__('filament-shield::filament-shield.field.team.placeholder'))
@@ -63,6 +68,7 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     ->options(fn (): Arrayable => Utils::getTenantModel() ? Utils::getTenantModel()::pluck('name', 'id') : collect())
                                     ->hidden(fn (): bool => ! (static::shield()->isCentralApp() && Utils::isTenancyEnabled()))
                                     ->dehydrated(fn (): bool => ! (static::shield()->isCentralApp() && Utils::isTenancyEnabled())),
+
                                 ShieldSelectAllToggle::make('select_all')
                                     ->onIcon('heroicon-s-shield-check')
                                     ->offIcon('heroicon-s-shield-exclamation')

--- a/src/Resources/RoleResource/Pages/CreateRole.php
+++ b/src/Resources/RoleResource/Pages/CreateRole.php
@@ -18,7 +18,7 @@ class CreateRole extends CreateRecord
     {
         $this->permissions = collect($data)
             ->filter(function ($permission, $key) {
-                return ! in_array($key, ['name', 'guard_name', 'select_all', Utils::getTenantModelForeignKey()]);
+                return ! in_array($key, ['name', 'guard_name', 'select_all', 'copy_another_role', Utils::getTenantModelForeignKey()]);
             })
             ->values()
             ->flatten()

--- a/src/Resources/RoleResource/Pages/EditRole.php
+++ b/src/Resources/RoleResource/Pages/EditRole.php
@@ -26,7 +26,7 @@ class EditRole extends EditRecord
     {
         $this->permissions = collect($data)
             ->filter(function ($permission, $key) {
-                return ! in_array($key, ['name', 'guard_name', 'select_all', Utils::getTenantModelForeignKey()]);
+                return ! in_array($key, ['name', 'guard_name', 'select_all', 'copy_another_role', Utils::getTenantModelForeignKey()]);
             })
             ->values()
             ->flatten()


### PR DESCRIPTION
Sometimes we need to copy role permissions from available role when it's looks similiar, so it's well be nice if it will be added as a default.
<img width="1439" alt="Screen Shot 2025-03-21 at 16 40 46" src="https://github.com/user-attachments/assets/27709298-82ae-46df-9c5b-aa9be58cc474" />
