### PR TITLE
fix: use proper localization for custom permission labels

### DIFF
--- a/src/Traits/HasShieldFormComponents.php
+++ b/src/Traits/HasShieldFormComponents.php
@@ -118,7 +118,9 @@ trait HasShieldFormComponents
     {
         return FilamentShield::getCustomPermissions()
             ->mapWithKeys(fn ($customPermission) => [
-                $customPermission => static::shield()->hasLocalizedPermissionLabels() ? str($customPermission)->headline()->toString() : $customPermission,
+                $customPermission => static::shield()->hasLocalizedPermissionLabels()
+                    ? FilamentShield::getLocalizedResourcePermissionLabel($customPermission)
+                    : $customPermission,
             ])
             ->toArray();
     }


### PR DESCRIPTION
Replace simple string transformation with dedicated localization method to ensure custom permission labels are properly translated when localization is enabled.