### PR TITLE
Allow multiple policy directories

### DIFF
--- a/src/Commands/Concerns/CanGeneratePolicy.php
+++ b/src/Commands/Concerns/CanGeneratePolicy.php
@@ -73,8 +73,7 @@ trait CanGeneratePolicy
 
         $stubVariables['namespace'] = Str::of($path)->contains(['vendor', 'src'])
             ? 'App\\' . Utils::getPolicyNamespace()
-            : Str::of($namespace)->replace('Models', Utils::getPolicyNamespace());
-        /** @phpstan-ignore-line */
+            : Str::of($namespace)->replace('Models', Utils::getPolicyNamespace()); /** @phpstan-ignore-line */
         $stubVariables['model_name'] = $entity['model'];
         $stubVariables['model_fqcn'] = $namespace . '\\' . $entity['model'];
         $stubVariables['model_variable'] = Str::of($entity['model'])->camel();

--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -195,7 +195,7 @@ class GenerateCommand extends Command
                 if ($this->generatorOption === 'policies_and_permissions') {
                     $policyPath = $this->generatePolicyPath($entity);
                     /** @phpstan-ignore-next-line */
-                    if (! $this->option('ignore-existing-policies') || ($this->option('ignore-existing-policies') && ! $this->fileExists($policyPath))) {
+                    if (! Str::of($policyPath)->contains(['vendor', 'src']) && (! $this->option('ignore-existing-policies') || ($this->option('ignore-existing-policies') && ! $this->fileExists($policyPath)))) {
                         $this->copyStubToApp(static::getPolicyStub($entity['model']), $policyPath, $this->generatePolicyStubVariables($entity));
                     }
                     FilamentShield::generateForResource($entity);
@@ -204,7 +204,7 @@ class GenerateCommand extends Command
                 if ($this->generatorOption === 'policies') {
                     $policyPath = $this->generatePolicyPath($entity);
                     /** @phpstan-ignore-next-line */
-                    if (! $this->option('ignore-existing-policies') || ($this->option('ignore-existing-policies') && ! $this->fileExists($policyPath))) {
+                    if (! Str::of($policyPath)->contains(['vendor', 'src']) && (! $this->option('ignore-existing-policies') || ($this->option('ignore-existing-policies') && ! $this->fileExists($policyPath)))) {
                         $this->copyStubToApp(static::getPolicyStub($entity['model']), $policyPath, $this->generatePolicyStubVariables($entity));
                     }
                 }

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -254,6 +254,15 @@ class Utils
         return config('filament-shield.discovery.discover_all_pages', false);
     }
 
+    public static function getPolicyPaths(): array
+    {
+        $paths = config('filament-shield.generator.policy_directories', ['app/Policies']);
+
+        return collect($paths)
+            ->map(fn($path) => Str::of($path)->replace('\\', DIRECTORY_SEPARATOR)->toString())
+            ->toArray();
+    }
+
     public static function getPolicyPath(): string
     {
         return Str::of(config('filament-shield.generator.policy_directory', 'Policies'))
@@ -265,7 +274,15 @@ class Utils
     {
         $filesystem = new Filesystem;
 
-        return (bool) $filesystem->exists(app_path(static::getPolicyPath() . DIRECTORY_SEPARATOR . 'RolePolicy.php'));
+        foreach (static::getPolicyPaths() as $path) {
+            $fullPath = base_path($path . DIRECTORY_SEPARATOR . 'RolePolicy.php');
+
+            if ($filesystem->exists($fullPath)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static function isTenancyEnabled(): bool


### PR DESCRIPTION
This change allows the discovery of policies from more than just one directory, this is useful in case the policy directory contains nested policy directories, or if there is a package which contains it's own policies.