### PR TITLE
feat: Add Trait-Based Policy Generation 

### DIFF
--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -63,6 +63,7 @@ return [
         'option' => 'policies_and_permissions',
         'policy_directory' => 'Policies',
         'policy_namespace' => 'Policies',
+        'generate_trait_policies' => false, // <-- New option
     ],
 
     'exclude' => [

--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -296,11 +296,50 @@ class GenerateCommand extends Command
 
     protected static function getPolicyStub(string $model): string
     {
+        if (Utils::isTraitGenerationEnabled()) {
+            return 'TraitPolicy';
+        }
+
         if (Str::is(Str::of(Utils::getAuthProviderFQCN())->afterLast('\\'), $model)) {
             return 'UserPolicy';
         }
 
         return 'DefaultPolicy';
+    }
+
+    protected function generatePolicyStubVariables(array $entity): array
+    {
+        if (Utils::isTraitGenerationEnabled()) {
+            return [
+                'namespace' => 'App\\Policies',
+                'model_fqcn' => $entity['fqcn'],
+                'auth_model_fqcn' => Utils::getAuthProviderFQCN(),
+                'modelPolicy' => $entity['model'] . 'Policy',
+                'resource_name' => $entity['resource'],
+            ];
+        }
+        return [
+            'namespace' => 'App\\Policies',
+            'model_fqcn' => $entity['fqcn'],
+            'model_name' => $entity['model'],
+            'model_variable' => Str::camel($entity['model']),
+            'auth_model_fqcn' => Utils::getAuthProviderFQCN(),
+            'auth_model_name' => Str::of(Utils::getAuthProviderFQCN())->afterLast('\\'),
+            'auth_model_variable' => Str::camel(Str::of(Utils::getAuthProviderFQCN())->afterLast('\\')),
+            'modelPolicy' => $entity['model'] . 'Policy',
+            'ViewAny' => 'view_any_' . $entity['resource'],
+            'View' => 'view_' . $entity['resource'],
+            'Create' => 'create_' . $entity['resource'],
+            'Update' => 'update_' . $entity['resource'],
+            'Delete' => 'delete_' . $entity['resource'],
+            'Restore' => 'restore_' . $entity['resource'],
+            'ForceDelete' => 'force_delete_' . $entity['resource'],
+            'Replicate' => 'replicate_' . $entity['resource'],
+            'Reorder' => 'reorder_' . $entity['resource'],
+            'DeleteAny' => 'delete_any_' . $entity['resource'],
+            'ForceDeleteAny' => 'force_delete_any_' . $entity['resource'],
+            'RestoreAny' => 'restore_any_' . $entity['resource'],
+        ];
     }
 
     protected function resetConfigExclusionCondition(bool $condition): void

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -158,6 +158,11 @@ class Utils
         return (string) config('filament-shield.generator.option', 'policies_and_permissions');
     }
 
+    public static function isTraitGenerationEnabled(): bool
+    {
+        return (bool) config('filament-shield.generator.generate_trait_policies', false);
+    }
+
     public static function getGeneratorNamespace(): string
     {
         return (string) config('filament-shield.generator.namespace', 'Policies');

--- a/src/Traits/GeneralPoliciesTrait.php
+++ b/src/Traits/GeneralPoliciesTrait.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace BezhanSalleh\FilamentShield\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User;
+
+trait GeneralPoliciesTrait
+{
+    /**
+     * Get the permission suffix for the model.
+     * Can be overridden in the class using this trait.
+     *
+     * @return string
+     */
+    protected function getPermissionSuffix(): string
+    {
+
+        return '';
+    }
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @return bool
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('viewAny' . $this->getPermissionSuffix());
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return bool
+     */
+    public function view(User $user, Model $model): bool
+    {
+        return $user->can('view' . $this->getPermissionSuffix(), $model);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @return bool
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('create' . $this->getPermissionSuffix());
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return bool
+     */
+    public function update(User $user, Model $model): bool
+    {
+        return $user->can('update' . $this->getPermissionSuffix(), $model);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return bool
+     */
+    public function delete(User $user, Model $model): bool
+    {
+        return $user->can('delete' . $this->getPermissionSuffix(), $model);
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return bool
+     */
+    public function restore(User $user, Model $model): bool
+    {
+        return $user->can('restore' . $this->getPermissionSuffix(), $model);
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return bool
+     */
+    public function forceDelete(User $user, Model $model): bool
+    {
+        return $user->can('forceDelete' . $this->getPermissionSuffix(), $model);
+    }
+
+    /**
+     * Determine whether the user can delete any models.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @return bool
+     */
+    public function deleteAny(User $user): bool
+    {
+        return $user->can('deleteAny' . $this->getPermissionSuffix());
+    }
+
+    /**
+     * Determine whether the user can permanently delete any models.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @return bool
+     */
+    public function forceDeleteAny(User $user): bool
+    {
+        return $user->can('forceDeleteAny' . $this->getPermissionSuffix());
+    }
+
+    /**
+     * Determine whether the user can restore any models.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @return bool
+     */
+    public function restoreAny(User $user): bool
+    {
+        return $user->can('restoreAny' . $this->getPermissionSuffix());
+    }
+
+    /**
+     * Determine whether the user can replicate the model.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @param \Illuminate\Database\Eloquent\Model $model
+     * @return bool
+     */
+    public function replicate(User $user, Model $model): bool
+    {
+        return $user->can('replicate' . $this->getPermissionSuffix(), $model);
+    }
+
+    /**
+     * Determine whether the user can reorder models.
+     *
+     * @param \Illuminate\Foundation\Auth\User $user
+     * @return bool
+     */
+    public function reorder(User $user): bool
+    {
+        return $user->can('reorder' . $this->getPermissionSuffix());
+    }
+}

--- a/stubs/TraitPolicy.stub
+++ b/stubs/TraitPolicy.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Policies;
+
+use {{ model_fqcn }};
+use {{ auth_model_fqcn }};
+use BezhanSalleh\FilamentShield\Traits\GeneralPoliciesTrait;
+
+class {{ modelPolicy }}
+{
+    use GeneralPoliciesTrait;
+
+    /**
+     * Get the permission suffix for the model.
+     *
+     * @return string
+     */
+    protected function getPermissionSuffix(): string
+    {
+        return '_{{ resource_name }}';
+    }
+}


### PR DESCRIPTION
 Introduces an optional trait based policy generation approach.  This allows users to generate policies that utilize a common `GeneralPoliciesTrait` for defining standard CRUD permissions, reducing boilerplate in individual policy files.  The feature is controlled by a new configuration option `generator.generate_trait_policies` in `config/filament-shield.php`. When enabled, the `shield:generate` command will use a new `TraitPolicy.stub` to create policies that leverage this trait.

Includes:
- `GeneralPoliciesTrait.php` with common policy methods.
- `TraitPolicy.stub` for generating trait-based policies.
- Updates to `GenerateCommand.php` to handle the new stub and variables.
- New `generate_trait_policies` config option.
- `Utils::isTraitGenerationEnabled()` helper method.
- Documentation in README.md for the new feature.