### PR TITLE
[Fix] widget permissions on super admin

### DIFF
--- a/src/Traits/HasWidgetShield.php
+++ b/src/Traits/HasWidgetShield.php
@@ -10,7 +10,7 @@ trait HasWidgetShield
 {
     public static function canView(): bool
     {
-        return Filament::auth()->user()->can(static::getPermissionName()) || Filament::auth()->user()->hasRole(Utils::getSuperAdminName());
+        return Filament::auth()->user()->can(static::getPermissionName());
     }
 
     protected static function getPermissionName(): string


### PR DESCRIPTION
Fixing widget permissions doesn't applies on super_admin

Descriptions:
The current implementation includes an OR condition that grants the super_admin access to view all widgets, even if there are permissions set to hide widgets for the super_admin.