### PR TITLE
Fix #513 PHP_EOL

### DIFF
--- a/src/Stringer.php
+++ b/src/Stringer.php
@@ -53,8 +53,8 @@ class Stringer
         }
 
         // Get the start of the line and calculate indentation
-        $lineStartPos = strrpos(substr($this->content, 0, $startPos), PHP_EOL) ?: 0;
-        $lineEndPos = strpos($this->content, PHP_EOL, $startPos) ?: strlen($this->content);
+        $lineStartPos = strrpos(substr($this->content, 0, $startPos), "\n") ?: 0;
+        $lineEndPos = strpos($this->content, "\n", $startPos) ?: strlen($this->content);
 
         $line = substr($this->content, $lineStartPos, $lineEndPos - $lineStartPos);
         $indentation = preg_replace('/\S.*/', '', $line); // Capture indentation
@@ -97,7 +97,7 @@ class Stringer
 
             // Format the new content based on the newLine flag
             $formattedReplacement = $this->addNewLine
-                ? PHP_EOL . $indentation . trim($contentToPrepend)
+                ? "\n" . $indentation . trim($contentToPrepend)
                 : $indentation . trim($contentToPrepend);
 
             $this->addNewLine = false; // Reset flag
@@ -110,7 +110,7 @@ class Stringer
                 // Prepend the content with proper indentation
                 $newContent = $lineInfo['indentation'] . $this->getIndentation() . trim($contentToPrepend);
                 if ($this->addNewLine) {
-                    $newContent = PHP_EOL . $newContent;
+                    $newContent = "\n" . $newContent;
                     $this->addNewLine = false; // Reset the flag
                 }
                 $this->content = substr_replace(
@@ -156,7 +156,7 @@ class Stringer
 
             // Format the new content based on the newLine flag
             $formattedReplacement = $this->addNewLine
-                ? $indentation . trim($contentToAppend) . PHP_EOL
+                ? $indentation . trim($contentToAppend) . "\n"
                 : $indentation . trim($contentToAppend);
 
             $this->addNewLine = false; // Reset flag
@@ -165,11 +165,11 @@ class Stringer
             if ($this->content[$closingParenPos + 1] === ';') {
                 $this->content = substr_replace(
                     $this->content,
-                    PHP_EOL . $indentation . ';',
+                    "\n" . $indentation . ';',
                     $closingParenPos + 1,
                     0
                 );
-                $closingParenPos += strlen(PHP_EOL . $indentation . ';'); // Adjust closing position
+                $closingParenPos += strlen("\n" . $indentation . ';'); // Adjust closing position
             }
 
             // Insert the formatted replacement after the closing parenthesis
@@ -180,7 +180,7 @@ class Stringer
                 // Append the content with proper indentation
                 $newContent = $lineInfo['indentation'] . $this->getIndentation() . trim($contentToAppend);
                 if ($this->addNewLine) {
-                    $newContent = $newContent . PHP_EOL;
+                    $newContent = $newContent . "\n";
                     $this->addNewLine = false; // Reset the flag
                 }
                 $this->content = substr_replace(
@@ -279,7 +279,7 @@ class Stringer
         $lastPos = strrpos($this->content, $needle);
 
         if ($lastPos !== false) {
-            $lineStartPos = strrpos(substr($this->content, 0, $lastPos), PHP_EOL) ?: 0;
+            $lineStartPos = strrpos(substr($this->content, 0, $lastPos), "\n") ?: 0;
             $line = substr($this->content, $lineStartPos, $lastPos - $lineStartPos);
 
             preg_match('/^\s*/', $line, $matches);
@@ -287,7 +287,7 @@ class Stringer
 
             $formattedReplacement = $this->getIndentation() . trim($replacement);
             if ($this->addNewLine) {
-                $formattedReplacement = PHP_EOL . $formattedReplacement . PHP_EOL;
+                $formattedReplacement = "\n" . $formattedReplacement . "\n";
             }
 
             $this->addNewLine = false;
@@ -300,7 +300,7 @@ class Stringer
 
     protected function findMethodDeclaration(string $needle): ?array
     {
-        $lines = explode(PHP_EOL, $this->content);
+        $lines = explode("\n", $this->content);
         $normalizedNeedle = preg_replace('/\s+/', ' ', trim($needle));
 
         for ($i = 0; $i < count($lines); $i++) {
@@ -314,10 +314,10 @@ class Stringer
 
                 $startPos = 0;
                 for ($j = 0; $j < $i; $j++) {
-                    $startPos += strlen($lines[$j]) + strlen(PHP_EOL);
+                    $startPos += strlen($lines[$j]) + strlen("\n");
                 }
 
-                $endPos = $startPos + strlen($lines[$i]) + strlen(PHP_EOL) + strlen($lines[$i + 1]);
+                $endPos = $startPos + strlen($lines[$i]) + strlen("\n") + strlen($lines[$i + 1]);
                 $indentation = preg_replace('/\S.*/', '', $lines[$i]);
 
                 // Find the closing brace position
@@ -339,7 +339,7 @@ class Stringer
 
                 $methodEndPos = $startPos;
                 for ($j = $i; $j <= $methodEndLine; $j++) {
-                    $methodEndPos += strlen($lines[$j]) + strlen(PHP_EOL);
+                    $methodEndPos += strlen($lines[$j]) + strlen("\n");
                 }
 
                 return [
@@ -366,7 +366,7 @@ class Stringer
         // Split the block into individual method calls
         $methodCalls = array_map('trim', explode('->', $normalizedBlock));
 
-        $lines = explode(PHP_EOL, $this->content);
+        $lines = explode("\n", $this->content);
         $contentLength = count($lines);
 
         for ($i = 0; $i < $contentLength; $i++) {
@@ -399,12 +399,12 @@ class Stringer
                 // Calculate positions
                 $startPos = 0;
                 for ($j = 0; $j < $startLine; $j++) {
-                    $startPos += strlen($lines[$j]) + strlen(PHP_EOL);
+                    $startPos += strlen($lines[$j]) + strlen("\n");
                 }
 
                 $endPos = $startPos;
                 for ($j = $startLine; $j < $endLine; $j++) {
-                    $endPos += strlen($lines[$j]) + strlen(PHP_EOL);
+                    $endPos += strlen($lines[$j]) + strlen("\n");
                 }
 
                 $indentation = preg_replace('/\S.*/', '', $lines[$startLine]);
@@ -441,14 +441,14 @@ class Stringer
 
         if ($afterBlock && isset($lineInfo['is_method']) && $lineInfo['is_method']) {
             // For method declarations, get the lines of content
-            $lines = explode(PHP_EOL, $this->content);
+            $lines = explode("\n", $this->content);
 
             // Calculate proper indentation
             $methodIndent = $lineInfo['indentation'];
             $contentIndent = $methodIndent . str_repeat(' ', 4); // One level deeper than method
 
             // Format the content to append
-            $contentLines = explode(PHP_EOL, trim($contentToAppend));
+            $contentLines = explode("\n", trim($contentToAppend));
             $formattedContent = '';
             foreach ($contentLines as $index => $line) {
                 $trimmedLine = trim($line);
@@ -456,25 +456,25 @@ class Stringer
                     continue;
                 }
 
-                $formattedContent .= ($index > 0 ? PHP_EOL . $methodIndent : '') . $contentIndent . $trimmedLine;
+                $formattedContent .= ($index > 0 ? "\n" . $methodIndent : '') . $contentIndent . $trimmedLine;
             }
 
             // Add new line if flag is set
             if ($this->addNewLine) {
-                $formattedContent = $formattedContent . PHP_EOL;
+                $formattedContent = $formattedContent . "\n";
                 $this->addNewLine = false;
             }
 
             // Find position after opening brace
             $insertPos = 0;
             for ($i = 0; $i <= $lineInfo['opening_brace_line']; $i++) {
-                $insertPos += strlen($lines[$i]) + strlen(PHP_EOL);
+                $insertPos += strlen($lines[$i]) + strlen("\n");
             }
 
             // Insert the formatted content
             $this->content = substr_replace(
                 $this->content,
-                $formattedContent . PHP_EOL . "\n",
+                $formattedContent . "\n" . "\n",
                 $insertPos,
                 0
             );
@@ -482,7 +482,7 @@ class Stringer
             // Original append logic
             $newContent = $lineInfo['indentation'] . $this->getIndentation() . trim($contentToAppend);
             if ($this->addNewLine) {
-                $newContent = PHP_EOL . $newContent;
+                $newContent = "\n" . $newContent;
                 $this->addNewLine = false;
             }
 


### PR DESCRIPTION
Fixes installation on Windows by converting all `PHP_EOL` line endings to `\n`