### PR TITLE
Feat: Improve custom permissions for third party packages.

### DIFF
--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -115,9 +115,10 @@ class Utils
         }
     }
 
-    public static function getGeneralResourcePermissionPrefixes(): array
+    public static function getGeneralResourcePermissionPrefixes(string $resourceFQCN): array
     {
-        return config('filament-shield.permission_prefixes.resource');
+        return config("filament-shield.permission_prefixes.$resourceFQCN") ??
+            config('filament-shield.permission_prefixes.resource');
     }
 
     public static function getPagePermissionPrefix(): string
@@ -224,7 +225,7 @@ class Utils
     {
         return static::doesResourceHaveCustomPermissions($resourceFQCN)
             ? $resourceFQCN::getPermissionPrefixes()
-            : static::getGeneralResourcePermissionPrefixes();
+            : static::getGeneralResourcePermissionPrefixes($resourceFQCN);
     }
 
     public static function getRoleModel(): string


### PR DESCRIPTION
As explained in the docs you can set your default permission in the `permission_prefixes.resource` key of the config file, and you can define custom permissions per `Resource` by implementing the `HasShieldPermissions` contract and defining the permissions in the `getPermissionsPrefixes()` method.

Sounds great! But what if the resource is inside a vendor package and therefore we can't customize its permissions this way?

![image](https://github.com/user-attachments/assets/c8549b12-b219-41c9-a067-6ac98499b134)

This for example doesn't make sense for the [Filament Authentication log](https://github.com/TappNetwork/filament-authentication-log) package as the only interaction the user can have with the log is `view_any`.

This package already provides a [great way to handle Third-Party Plugins Policies](https://github.com/bezhanSalleh/filament-shield?tab=readme-ov-file#third-party-plugins-policies), but not to so much to handle their permissions.

This PR aims to solve this problem by allowing the developer to specify the permission prefixes for the `Resource` directly in the config file:

```php
'permission_prefixes' => [
        \Tapp\FilamentAuthenticationLog\Resources\AuthenticationLogResource::class => [
            'view_any',
        ],

        'resource' => [
         ...
        ],

        'page' => 'page',
        'widget' => 'widget',
    ],
```

The result:

![image](https://github.com/user-attachments/assets/2a3a121e-52bc-4979-87e8-be163e69b691)

![image](https://github.com/user-attachments/assets/8dca87be-71e7-419a-a996-fa78cb8ab794)


Please let me know what you think about it. I'm open to suggestions on how to improve it, if you like the idea.