### PR TITLE
fix: allow Resource to be part of the Filament Resource name

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -330,7 +330,7 @@ class FilamentShield
     {
         return Str::of($resource)
             ->afterLast('Resources\\')
-            ->before('Resource')
+            ->beforeLast('Resource')
             ->replace('\\', '')
             ->snake()
             ->replace('_', '::');


### PR DESCRIPTION
Thanks for a great package man. I bumped into a situation where I have a filament resource called `ResourceGroupResource`, which generates empty permissions, as it removes everything before the first instance of `Resource`. This fix allows for filament resources having names that includes the keyword `Resource`.

Thanks.