### PR TITLE
Fix typo in Spanish translation for force delete action

### DIFF
--- a/resources/lang/es/filament-shield.php
+++ b/resources/lang/es/filament-shield.php
@@ -70,7 +70,7 @@ return [
         'update' => 'Actualizar',
         'delete' => 'Eliminar un registro en particular',
         'delete_any' => 'Eliminar varios registros a la vez',
-        'force_delete' => 'Forzar elminación de un registro en particular',
+        'force_delete' => 'Forzar eliminación de un registro en particular',
         'force_delete_any' => 'Forzar eliminación de varios registros',
         'restore' => 'Restaurar un registro en particular',
         'reorder' => 'Reordenar',


### PR DESCRIPTION
From: "Forzar elminación"
To: "Eliminar eliminación"