### PR TITLE
[v4] Deleting ->hasViews(static::$name)

### DIFF
--- a/src/FilamentShieldServiceProvider.php
+++ b/src/FilamentShieldServiceProvider.php
@@ -32,7 +32,6 @@ class FilamentShieldServiceProvider extends PackageServiceProvider
             ->name(static::$name)
             ->hasConfigFile()
             ->hasTranslations()
-            ->hasViews(static::$name)
             ->hasCommands($this->getCommands());
     }
 


### PR DESCRIPTION
Deleting ->hasViews(static::$name) as x4 does not have views anymore and optimizing views will show the following error

`{Project Path}/vendor/bezhansalleh/filament-shield/src/../resources/views" directory does not exist`