### PR TITLE
Fix 4.x: is tenancy is enabled but not centralApp still pass the team ID

### DIFF
--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -13,7 +13,6 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Panel;
@@ -23,7 +22,6 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Unique;
 
@@ -68,14 +66,8 @@ class RoleResource extends Resource implements HasShieldPermissions
                                     ->nullable()
                                     ->maxLength(255),
 
-                                Select::make(config('permission.column_names.team_foreign_key'))
-                                    ->label(__('filament-shield::filament-shield.field.team'))
-                                    ->placeholder(__('filament-shield::filament-shield.field.team.placeholder'))
-                                    /** @phpstan-ignore-next-line */
-                                    ->default([Filament::getTenant()?->id])
-                                    ->options(fn (): Arrayable => Utils::getTenantModel() ? Utils::getTenantModel()::pluck('name', 'id') : collect())
-                                    ->hidden(fn (): bool => ! (static::shield()->isCentralApp() && Utils::isTenancyEnabled()))
-                                    ->dehydrated(fn (): bool => ! (static::shield()->isCentralApp() && Utils::isTenancyEnabled())),
+                                static::getTenantOptions(),
+
                                 static::getSelectAllFormComponent(),
 
                             ])

--- a/src/Traits/HasShieldFormComponents.php
+++ b/src/Traits/HasShieldFormComponents.php
@@ -8,7 +8,10 @@ use BezhanSalleh\FilamentShield\Facades\FilamentShield;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use BezhanSalleh\FilamentShield\Support\Utils;
 use Filament\Actions\Action;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Grid;
@@ -16,6 +19,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Components\Utilities\Set;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 use Livewire\Component as Livewire;
@@ -280,6 +284,26 @@ trait HasShieldFormComponents
     public static function shield(): FilamentShieldPlugin
     {
         return FilamentShieldPlugin::get();
+    }
+
+    public static function getTenantOptions(): ?Component
+    {
+        if (! Utils::isTenancyEnabled()) {
+            return null;
+        }
+
+        if (static::shield()->isCentralApp()) {
+            return Select::make(config('permission.column_names.team_foreign_key'))
+                ->label(__('filament-shield::filament-shield.field.team'))
+                ->placeholder(__('filament-shield::filament-shield.field.team.placeholder'))
+                /** @phpstan-ignore-next-line */
+                ->default([Filament::getTenant()?->id])
+                ->options(fn (): Arrayable => Utils::getTenantModel() ? Utils::getTenantModel()::pluck('name', 'id') : collect());
+        }
+
+        return Hidden::make(config('permission.column_names.team_foreign_key'))
+            /** @phpstan-ignore-next-line */
+            ->default(Filament::getTenant()?->id);
     }
 
     public static function getSelectAllFormComponent(): Component


### PR DESCRIPTION
Hi,

I was using your amazing plugin for the first time in a new Filament 4 multi tenancy environment and I noticed that when creating a new role in a certain tenant I got an error because the team ID was not passed in the $data

This fix checks this and passes a hidden variable with the team ID

Lemme know what you think?