### PR TITLE
feat: customizable navigation group label using config

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,18 +323,13 @@ FilamentShield::configurePermissionIdentifierUsing(
 > Keep in mind that ensuring the uniqueness of the permission identifier is now up to you.
 
 ##### Custom Navigation Group
-By default the english translation renders Roles and Permissions under 'Filament Shield' if you wish to change this, first publish the [translations files](#translations) and change the relative locale to the group of your choosing for example:
+By default the navigation group renders using the `filament-shield::filament-shield.nav.group` translation key. You may define a custom translation key in your `filament-shield.php` config file. For example:
 
 ```php
-'nav.group' => 'Filament Shield',
+'shield_resource' => [
+    'navigation_group_label' => 'nav.group.admin',
+],
 ```
-
-to
-
-```php
-'nav.group' => 'User Management',
-```
-apply this to each language you have groups in.
 
 #### Pages
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ FilamentShield::configurePermissionIdentifierUsing(
 > Keep in mind that ensuring the uniqueness of the permission identifier is now up to you.
 
 ##### Custom Navigation Group
-By default the navigation group renders using the `filament-shield::filament-shield.nav.group` translation key. You may define a custom translation key in your `filament-shield.php` config file. For example:
+By default, the navigation group renders using the `filament-shield::filament-shield.nav.group` translation key. You may define a custom translation key in your `filament-shield.php` config file. For example:
 
 ```php
 'shield_resource' => [

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -7,6 +7,7 @@ return [
         'navigation_sort' => -1,
         'navigation_badge' => true,
         'navigation_group' => true,
+		'navigation_group_label' => 'filament-shield::filament-shield.nav.group',
         'sub_navigation_position' => null,
         'is_globally_searchable' => false,
         'show_model_path' => true,

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -171,7 +171,7 @@ class RoleResource extends Resource implements HasShieldPermissions
     public static function getNavigationGroup(): ?string
     {
         return Utils::isResourceNavigationGroupEnabled()
-            ? __('filament-shield::filament-shield.nav.group')
+            ? __(Utils::getResourceNavigationGroupLabel())
             : '';
     }
 

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -63,6 +63,11 @@ class Utils
         return config('filament-shield.shield_resource.navigation_group', true);
     }
 
+    public static function getResourceNavigationGroupLabel(): string
+    {
+        return config('filament-shield.shield_resource.navigation_group_label', 'filament-shield::filament-shield.nav.group');
+    }
+
     public static function isResourceGloballySearchable(): bool
     {
         return config('filament-shield.shield_resource.is_globally_searchable', false);


### PR DESCRIPTION
Removes the need to publish translation files to define a custom navigation group.

I decided to replace the previous method in the docs, but let me know if you would like to keep it.