### PR TITLE
feat: include editTenantProfile page in permission generation

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -204,6 +204,9 @@ class FilamentShield
             foreach (Filament::getPanels() as $panel) {
                 $pages = array_merge($pages, $panel->getPages());
             }
+            if (Filament::hasTenantProfile()) {
+                $pages[] = Filament::getTenantProfilePage();
+            }
             $pages = array_unique($pages);
         }
 


### PR DESCRIPTION
This change adds support for the EditTenantProfile page when generating permissions.

- First, check if `Filament::hasTenantEditProfilePage()` returns true.  
- If so, call `Filament::getTenantEditProfilePage()` to retrieve the page class.  
- Append that page to the pages array for permission discovery.  
- Now, running `php artisan shield:generate --all` will generate permissions
  for the EditTenantProfile page as well.
