### PR TITLE
SuperAdmin Command Enhancements and Robustness Fix (3.x)

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -19,7 +19,10 @@ class InstallCommand extends Command implements PromptsForMissingInput
     use Concerns\CanRegisterPlugin;
 
     /** @var string */
-    protected $signature = 'shield:install {panel} {--tenant}';
+    protected $signature = 'shield:install {panel}
+     {--tenant}
+     {--panel-provider-path= : Filament provider path is determined according to the app base path.}';
+
 
     /** @var string */
     protected $description = 'Install and configure shield for the given Filament Panel';
@@ -35,13 +38,15 @@ class InstallCommand extends Command implements PromptsForMissingInput
         $panel = Filament::getPanel($this->argument('panel') ?? null);
 
         $tenant = $this->option('tenant') ? config()->get('filament-shield.tenant_model') : null;
-
+        $panelProviderPath=$this->option('panel-provider-path');
         $tenantModelClass = str($tenant)
             ->prepend('\\')
             ->append('::class')
             ->toString();
 
-        $panelPath = app_path(
+        $panelPath = !empty($panelProviderPath)?
+            base_path($panelProviderPath):
+            app_path(
             (string) str($panel->getId())
                 ->studly()
                 ->append('PanelProvider')

--- a/src/Commands/SuperAdminCommand.php
+++ b/src/Commands/SuperAdminCommand.php
@@ -19,6 +19,7 @@ class SuperAdminCommand extends Command
 {
     public $signature = 'shield:super-admin
         {--user= : ID of user to be made super admin.}
+        {--user-column= : The column in the user table used to search for the user option value.}
         {--panel= : Panel ID to get the configuration from.}
         {--tenant= : Team/Tenant ID to assign role to user.}
     ';
@@ -58,7 +59,11 @@ class SuperAdminCommand extends Command
         $tenantId = $this->option('tenant');
 
         if ($this->option('user')) {
-            $this->superAdmin = static::getUserModel()::findOrFail($this->option('user'));
+            if (empty($this->option('user-column'))){
+                $this->superAdmin = static::getUserModel()::findOrFail($this->option('user'));
+            }else{
+                $this->superAdmin = static::getUserModel()::where($this->option('user-column'),$this->option('user'))->firstOrFail();
+            }
         } elseif ($usersCount === 1) {
             $this->superAdmin = static::getUserModel()::first();
         } elseif ($usersCount > 1) {


### PR DESCRIPTION
Summary of changes

- Improved Panel Provider Path Handling: Added support for specifying a custom `--panel-provider-path` option in the `InstallCommand`, improving the flexibility for projects where the Filament panel provider file path differs from the default location.

- When the Filament user table does not have an id column, creating a super admin user with Shield fails.
This issue has now been resolved by adding a `--user-column option` to `SuperAdminCommand.php`.

No refactoring or unrelated changes were made; all updates focus on improving installation command flexibility and multi-tenancy support, as reflected in the commits linked.

	
These changes improve installation flexibility for customized project structures and enhance multi-tenancy support during the package setup.