### PR TITLE
Update CheckboxList label() to hiddenLabel()

### DIFF
--- a/src/Traits/HasShieldFormComponents.php
+++ b/src/Traits/HasShieldFormComponents.php
@@ -230,7 +230,7 @@ trait HasShieldFormComponents
     public static function getCheckboxListFormComponent(string $name, array $options, bool $searchable = true, array | int | string | null $columns = null, array | int | string | null $columnSpan = null): Component
     {
         return CheckboxList::make($name)
-            ->label('')
+            ->hiddenLabel()
             ->options(fn (): array => $options)
             ->searchable($searchable)
             ->live()


### PR DESCRIPTION
This will prevent to display the default label value

Before:
<img width="321" height="242" alt="before" src="https://github.com/user-attachments/assets/8cbc124e-1302-4eba-b42b-4bd3ce0b63ef" />

After:
<img width="328" height="216" alt="after" src="https://github.com/user-attachments/assets/288971ed-c091-41f3-aa32-2a47c05273d5" />
