### PR TITLE
feat: Add custom permission names for pages to override defaults for better namespacing

### DIFF
--- a/src/Traits/HasPageShield.php
+++ b/src/Traits/HasPageShield.php
@@ -47,13 +47,18 @@ trait HasPageShield
 
     protected static function getPermissionName(): string
     {
-        return Str::of(class_basename(static::class))
+        return Str::of(static::getPermissionIdentifier())
             ->prepend(
                 Str::of(Utils::getPagePermissionPrefix())
                     ->append('_')
                     ->toString()
             )
             ->toString();
+    }
+
+    protected static function getPermissionIdentifier(): string
+    {
+        return class_basename(static::class);
     }
 
     public static function shouldRegisterNavigation(array $parameters = []): bool


### PR DESCRIPTION
Allows names like admin::dashboard instead of page_dashboard, for ease of use and sometimes same naming's of pages that show on GUI. 