### PR TITLE
refactor(permissions): simplify default permission identifier extraction

### DIFF
--- a/src/FilamentShield.php
+++ b/src/FilamentShield.php
@@ -340,9 +340,8 @@ class FilamentShield
     protected function getDefaultPermissionIdentifier(string $resource): string
     {
         return Str::of($resource)
-            ->afterLast('Resources\\')
+            ->afterLast('\\')
             ->beforeLast('Resource')
-            ->replace('\\', '')
             ->snake()
             ->replace('_', '::');
     }


### PR DESCRIPTION
This PR fixes the permission identifier generation on Filament v4. Due to the new resource directory structure, identifiers were being derived from path segments, producing malformed strings.

When resources live under nested directories (e.g. `App\Filament\Resources\Users\UserResource`), the current logic builds permission names using directory fragments, which led to outputs like:

- view_users::user
- create_books::book