### PR TITLE
Change label method to hiddenLabel in CheckboxList

### DIFF
--- a/src/Traits/HasShieldFormComponents.php
+++ b/src/Traits/HasShieldFormComponents.php
@@ -222,7 +222,7 @@ trait HasShieldFormComponents
     public static function getCheckboxListFormComponent(string $name, array $options, bool $searchable = true, array | int | string | null $columns = null, array | int | string | null $columnSpan = null): Component
     {
         return Forms\Components\CheckboxList::make($name)
-            ->label('')
+            ->hiddenLabel()
             ->options(fn (): array => $options)
             ->searchable($searchable)
             ->afterStateHydrated(


### PR DESCRIPTION
This pull request introduces a minor change to the `getCheckboxListFormComponent` method in `HasShieldFormComponents.php`. The update improves the accessibility and clarity of the form component by hiding the label instead of setting it to an empty string. 

* Changed `->label('')` to `->hiddenLabel()` in the `getCheckboxListFormComponent` method to ensure the label is properly hidden rather than just empty.