### PR TITLE
Fix: Undefined array key in CanManipulateFiles (#615)

### DIFF
--- a/src/Commands/Concerns/CanManipulateFiles.php
+++ b/src/Commands/Concerns/CanManipulateFiles.php
@@ -27,7 +27,7 @@ trait CanManipulateFiles
     {
         $filesystem = app(Filesystem::class);
 
-        if (! $this->fileExists($stubPath = base_path("stubs/filament-shield/{$stub}.stub"))) {
+        if (!$this->fileExists($stubPath = base_path("stubs/filament-shield/{$stub}.stub"))) {
             $stubPath = $this->getDefaultStubPath() . "/{$stub}.stub";
         }
 
@@ -38,7 +38,7 @@ trait CanManipulateFiles
         foreach ($replacements as $methodName => $replacement) {
             if (is_array($replacement) && isset($replacement['stub'], $replacement['permission'])) {
 
-                if (! $this->fileExists($methodStubPath = base_path("stubs/filament-shield/{$stub}.stub"))) {
+                if (!$this->fileExists($methodStubPath = base_path("stubs/filament-shield/{$stub}.stub"))) {
                     $methodStubPath = $this->getDefaultStubPath() . "/{$replacement['stub']}.stub";
                 }
 
@@ -56,10 +56,16 @@ trait CanManipulateFiles
         // Replace methods placeholder with generated methods
         $stub = $stub->replace('{{ methods }}', $methods);
 
+        // Only replace placeholders if they exist in the $replacements array
+        $namespace = $replacements['namespace'] ?? '';
+        $authModelFqcn = $replacements['auth_model_fqcn'] ?? '';
+        $modelFqcn = $replacements['model_fqcn'] ?? '';
+        $modelPolicy = $replacements['modelPolicy'] ?? '';
+
         // Replace other placeholders in the policy class
         $stub = (string) $stub->replace(
             ['{{ namespace }}', '{{ auth_model_fqcn }}', '{{ model_fqcn }}', '{{ modelPolicy }}'],
-            [$replacements['namespace'], $replacements['auth_model_fqcn'], $replacements['model_fqcn'], $replacements['modelPolicy']]
+            [$namespace, $authModelFqcn, $modelFqcn, $modelPolicy]
         );
 
         $this->writeFile($targetPath, $stub);
@@ -96,7 +102,7 @@ trait CanManipulateFiles
     {
         $filesystem = new Filesystem;
 
-        if (! $this->fileExists($destination)) {
+        if (!$this->fileExists($destination)) {
             $filesystem->copy($source, $destination);
             $this->components->info("$destination file published!");
 


### PR DESCRIPTION
### **Description**

**Problem:**
When running `php artisan shield:seeder --generate`, the command fails with an `Undefined array key` error in `CanManipulateFiles.php` if the `$replacements` array is missing required keys (`namespace`, `auth_model_fqcn`, `model_fqcn`, or `modelPolicy`). This prevents the seeder file from being generated.

**Root Cause:**
The code assumes these keys are always present in the `$replacements` array, but in some cases, they may be missing, causing the error.

**Solution:**
Added null coalescing operators (`??`) to provide default empty strings for missing keys in the `copyStubToApp` method. This ensures the command runs smoothly even if some keys are not set, without breaking existing functionality.

**Changes Made:**
- Updated `copyStubToApp` in `CanManipulateFiles.php` to safely handle missing keys:
  ```php
  $namespace = $replacements['namespace'] ?? '';
  $authModelFqcn = $replacements['auth_model_fqcn'] ?? '';
  $modelFqcn = $replacements['model_fqcn'] ?? '';
  $modelPolicy = $replacements['modelPolicy'] ?? '';
  ```

**Testing:**
- Tested locally in a Laravel project (`schoolbus`) by running `php artisan shield:seeder --generate`.
- Confirmed the seeder file is now generated successfully without errors.

**Checklist:**
- [x] Follows [[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
- [x] No breaking changes to the public API.
- [x] Backward compatible.
- [x] Fixes #615.

---

### **Additional Notes**
This is a defensive fix that ensures robustness in edge cases. No new tests are required, as the change only adds fallback values for missing array keys.

---