### PR TITLE
fix(stubs): correct custom stub path resolution

### DIFF
--- a/src/Commands/Concerns/CanManipulateFiles.php
+++ b/src/Commands/Concerns/CanManipulateFiles.php
@@ -38,7 +38,7 @@ trait CanManipulateFiles
         foreach ($replacements as $methodName => $replacement) {
             if (is_array($replacement) && isset($replacement['stub'], $replacement['permission'])) {
 
-                if (! $this->fileExists($methodStubPath = base_path("stubs/filament-shield/{$stub}.stub"))) {
+                if (! $this->fileExists($methodStubPath = base_path("stubs/filament-shield/{$replacement['stub']}.stub"))) {
                     $methodStubPath = $this->getDefaultStubPath() . "/{$replacement['stub']}.stub";
                 }
 


### PR DESCRIPTION
Previously, Shield was looking for custom stubs using the `$stub` variable:

    stubs/filament-shield/{$stub}.stub

This caused issues when replacement-specific stubs were expected.   Updated the logic to consistently use:

    stubs/filament-shield/{$replacement['stub']}.stub

so that the correct replacement stub file is resolved first, falling back to the default stub path if not found.