### PR TITLE
Fix: ensure selected Panel guard is respected and include guard when creating roles/permissions (fixes #647)

### DIFF
--- a/src/Commands/SuperAdminCommand.php
+++ b/src/Commands/SuperAdminCommand.php
@@ -66,6 +66,8 @@ class SuperAdminCommand extends Command
             required: true
         );
 
+        Filament::setCurrentPanel($this->panel);
+
         $usersCount = static::getUserModel()::count();
         $tenantId = $this->option('tenant');
 

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -180,27 +180,30 @@ class Utils
 
     public static function createRole(?string $name = null, int | string | null $tenantId = null): Role
     {
+        $guardName = static::getFilamentAuthGuard();
+
         if (static::isTenancyEnabled()) {
             return static::getRoleModel()::firstOrCreate(
                 [
                     'name' => $name ?? static::getConfig()->super_admin->name,
                     static::getTenantModelForeignKey() => $tenantId,
+                    'guard_name' => $guardName,
                 ],
-                ['guard_name' => static::getFilamentAuthGuard()]
             );
         }
 
         return static::getRoleModel()::firstOrCreate(
-            ['name' => $name ?? static::getSuperAdminName()],
-            ['guard_name' => static::getFilamentAuthGuard()]
+            [
+                'name' => $name ?? static::getSuperAdminName(),
+                'guard_name' => $guardName,
+            ],
         );
     }
 
     public static function createPermission(string $name): string
     {
         return static::getPermissionModel()::firstOrCreate(
-            ['name' => $name],
-            ['guard_name' => static::getFilamentAuthGuard()]
+            ['name' => $name, 'guard_name' => static::getFilamentAuthGuard()],
         )->name;
     }
 


### PR DESCRIPTION
# Description: 
This PR fixes two related issues reported in #647.

## What was happening

In multi-Panel setups where multiple guards are configured, the selected Panel was not being set as the “current” panel. As a result, code that relied on the current panel to determine the active guard retrieved the wrong guard.

Role and permission creation only considered the name field and ignored the guard. This caused incorrect role/permission lookup and collisions when multiple guards exist.
What this change does.

This ensures the selected Panel is properly set as current, so the correct guard is resolved for subsequent operations.

Include guard checking when creating and resolving roles and permissions to avoid collisions across guards. Role/permission lookups and creations now respect both name and guard_name (or equivalent) where applicable.

## The fix

Correctly setting the current Panel allows the correct guard to be retrieved.

Adding the guard name on the first parameter of “firstOrCreate” get the correct guard for the current panel