### PR TITLE
Update localization key in filament-shield config

### DIFF
--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -146,7 +146,7 @@ return [
 
     'localization' => [
         'enabled' => false,
-        'key' => 'filament-shield::filament-shield',
+        'key' => 'filament-shield::filament-shield.resource_permission_prefixes_labels',
     ],
 
     /*


### PR DESCRIPTION
This pull request includes a minor update to the Filament Shield configuration. The change updates the localization key to use a more specific prefix for resource permission labels.

* Configuration update:
  * In `config/filament-shield.php`, changed the localization `key` from `'filament-shield::filament-shield'` to `'filament-shield::filament-shield.resource_permission_prefixes_labels'` to better target resource permission label translations.