### PR TITLE
Fix :Windows compatibility by enabling TTY only when supported

### DIFF
--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -114,14 +114,27 @@ class SetupCommand extends Command
 
         $makePanelTenantable = $this->shouldConfigureTenancy && confirm("Would you like to make the `{$panel}` panel tenantable?", false);
 
-        Process::forever()->tty()->run("php artisan shield:install {$panel} " . ($makePanelTenantable ? '--tenant' : ''));
+        $process = Process::forever();
+        if (Process::isTtySupported()) {
+            $process->tty();
+        }
+        $process->run("php artisan shield:install {$panel} " . ($makePanelTenantable ? '--tenant' : ''));
 
         if (confirm("Would you like to run `shield:generate` for `{$panel}` Panel?", true)) {
-            Process::forever()->tty()->run("php artisan shield:generate --all --panel={$panel}");
+           $process = Process::forever();
+            if (Process::isTtySupported()) {
+                $process->tty();
+             }
+           $process->run("php artisan shield:generate --all --panel={$panel}");
+            
         }
         if (confirm("Would you like to run `shield:super-admin` for `{$panel}` Panel?", true)) {
             $this->newLine();
-            Process::forever()->tty()->run("php artisan shield:super-admin --panel={$panel}");
+            $process = Process::forever();
+            if (Process::isTtySupported()) {
+                $process->tty();
+            }
+            $process->run("php artisan shield:super-admin --panel={$panel}");
         }
     }
 


### PR DESCRIPTION
Fix: disable TTY on unsupported platforms

Updated SetupCommand to conditionally call ->tty() only when Process::isTtySupported() returns true.
This prevents RuntimeException: TTY mode is not supported on Windows platform errors.