### PR TITLE
Fixes #678: Use tenant ID for team permissions and clear cached permissions

### DIFF
--- a/src/Middleware/SyncShieldTenant.php
+++ b/src/Middleware/SyncShieldTenant.php
@@ -7,6 +7,7 @@ namespace BezhanSalleh\FilamentShield\Middleware;
 use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\Request;
+use Spatie\Permission\PermissionRegistrar;
 use Symfony\Component\HttpFoundation\Response;
 
 class SyncShieldTenant
@@ -18,9 +19,9 @@ class SyncShieldTenant
      */
     public function handle(Request $request, Closure $next): Response
     {
-
-        if (Filament::hasTenancy()) {
-            setPermissionsTeamId(Filament::getTenant());
+        if (Filament::hasTenancy() && $tenant = Filament::getTenant()) {
+            setPermissionsTeamId($tenant->getKey());
+            app(PermissionRegistrar::class)->forgetCachedPermissions();
         }
 
         return $next($request);


### PR DESCRIPTION
This PR fixes an issue in the SyncShieldTenant middleware where the tenant model instance was passed directly to setPermissionsTeamId() instead of the tenant primary key.
Additionally, the Spatie permission cache is now explicitly cleared after syncing the tenant to ensure permissions are resolved correctly when switching tenants in a multi-tenant Filament setup.
