### PR TITLE
Sync all permissions to super_admin role regardless of tenancy setup

### DIFF
--- a/src/Commands/SuperAdminCommand.php
+++ b/src/Commands/SuperAdminCommand.php
@@ -88,12 +88,12 @@ class SuperAdminCommand extends Command
 
             setPermissionsTeamId($tenantId);
             $this->superAdminRole = Utils::createRole(tenantId: $tenantId);
-            $this->superAdminRole->syncPermissions(Utils::getPermissionModel()::pluck('id'));
-
         } else {
             $this->superAdminRole = Utils::createRole();
         }
 
+        $this->superAdminRole->syncPermissions(Utils::getPermissionModel()::pluck('id'));
+        
         $this->superAdmin
             ->unsetRelation('roles')
             ->unsetRelation('permissions');


### PR DESCRIPTION
When running the super admin command in a single tenant environment, the `super_admin` role gets created without any permissions assigned to it.

This fixes the issue so that all permissions are always synced, regardless of whether the app is a single tenant or multi-tenant.