### PR TITLE
Update Indonesian Translations

### DIFF
--- a/resources/lang/id/filament-shield.php
+++ b/resources/lang/id/filament-shield.php
@@ -72,7 +72,7 @@ return [
         'update' => 'Ubah',
         'delete' => 'Hapus',
         'delete_any' => 'Hapus semua',
-        'force_delete' => 'Hapus Permanen',
+        'force_delete' => 'Hapus permanen',
         'force_delete_any' => 'Hapus permanen semua',
         'restore' => 'Pulihkan',
         'replicate' => 'Duplikat',


### PR DESCRIPTION
This simple PR updates the Indonesian translations to sound more natural. The name "Filament Shield" is kept as-is and not translated to "Pelindung".