### PR TITLE
Add deleteAny to default policy methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Shield automatically generates policies for your Resources' Models.
     'merge' => true,
     'generate' => true,
     'methods' => [
-        'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+        'viewAny', 'view', 'create', 'update', 'delete', 'deleteAny', 'restore',
         'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',
     ],
     'single_parameter_methods' => [

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -122,7 +122,7 @@ return [
         'merge' => true,
         'generate' => true,
         'methods' => [
-            'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+            'viewAny', 'view', 'create', 'update', 'delete', 'deleteAny', 'restore',
             'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',
         ],
         'single_parameter_methods' => [


### PR DESCRIPTION
I'm not sure if this was excluded for a specific reason, but it seemed to me that deleteAny should be one of the default policy methods, especially as forceDeleteAny was already in there.