### PR TITLE
Fix policy path and namespace resolution for non-default policies.path config

### DIFF
--- a/src/Commands/Concerns/CanGeneratePolicy.php
+++ b/src/Commands/Concerns/CanGeneratePolicy.php
@@ -36,11 +36,13 @@ trait CanGeneratePolicy
                 ->toString();
         }
 
+        $modelRelativePath = Str::of($path)->after('Models' . DIRECTORY_SEPARATOR);
+
         /** @phpstan-ignore-next-line */
-        return Str::of($path)
-            ->replace('Models', Str::of(Utils::resolveNamespaceFromPath(Utils::getPolicyPath()))->afterLast('\\')->toString())
+        return Str::of(Utils::getPolicyPath())
+            ->append(DIRECTORY_SEPARATOR)
+            ->append($modelRelativePath)
             ->replaceLast('.php', 'Policy.php')
-            ->replace('\\', DIRECTORY_SEPARATOR)
             ->toString();
     }
 
@@ -65,11 +67,11 @@ trait CanGeneratePolicy
         $namespace = $reflectionClass->getNamespaceName();
         $path = $reflectionClass->getFileName();
 
-        $policyNamespace = Str::of(Utils::resolveNamespaceFromPath(Utils::getPolicyPath()))->afterLast('\\')->toString();
+        $policyBaseNamespace = Utils::resolveNamespaceFromPath(Utils::getPolicyPath());
 
         $stubVariables['namespace'] = Str::of($path)->contains(['vendor', 'src'])
-            ? Utils::resolveNamespaceFromPath(Utils::getPolicyPath())
-            : Str::of($namespace)->replace('Models', $policyNamespace)->toString(); /** @phpstan-ignore-line */
+            ? $policyBaseNamespace
+            : $policyBaseNamespace . Str::of($namespace)->after('Models')->toString(); /** @phpstan-ignore-line */
         $stubVariables['model_name'] = $entity['model'];
         $stubVariables['model_fqcn'] = $namespace . '\\' . $entity['model'];
         $stubVariables['model_variable'] = Str::of($entity['model'])->camel();

--- a/tests/Feature/Commands/CanGeneratePolicyTest.php
+++ b/tests/Feature/Commands/CanGeneratePolicyTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use BezhanSalleh\FilamentShield\Commands\Concerns\CanGeneratePolicy;
+use BezhanSalleh\FilamentShield\Facades\FilamentShield;
+use BezhanSalleh\FilamentShield\Support\Utils;
+use BezhanSalleh\FilamentShield\Tests\Fixtures\Models\Applications\Application;
+use BezhanSalleh\FilamentShield\Tests\Fixtures\Models\User;
+
+beforeEach(function () {
+    $this->policyGenerator = new class
+    {
+        use CanGeneratePolicy;
+
+        public function callGeneratePolicyPath(array $entity): string
+        {
+            return $this->generatePolicyPath($entity);
+        }
+
+        public function callGeneratePolicyStubVariables(array $entity): array
+        {
+            return $this->generatePolicyStubVariables($entity);
+        }
+    };
+});
+
+describe('generatePolicyPath', function () {
+    it('generates correct policy path for a flat model with a non-default policy path', function () {
+        $policyPath = app_path('Filament' . DIRECTORY_SEPARATOR . 'Policies');
+        config()->set('filament-shield.policies.path', $policyPath);
+
+        // Reset the PSR-4 cache so it re-reads composer.json
+        $reflection = new ReflectionClass(Utils::class);
+        $prop = $reflection->getProperty('psr4Cache');
+        $prop->setValue(null, null);
+
+        $entity = [
+            'modelFqcn' => User::class,
+            'model' => 'User',
+        ];
+
+        $result = $this->policyGenerator->callGeneratePolicyPath($entity);
+
+        expect($result)->toBe($policyPath . DIRECTORY_SEPARATOR . 'UserPolicy.php');
+    });
+
+    it('generates correct policy path for a nested model with a non-default policy path', function () {
+        $policyPath = app_path('Filament' . DIRECTORY_SEPARATOR . 'Policies');
+        config()->set('filament-shield.policies.path', $policyPath);
+
+        $reflection = new ReflectionClass(Utils::class);
+        $prop = $reflection->getProperty('psr4Cache');
+        $prop->setValue(null, null);
+
+        $entity = [
+            'modelFqcn' => Application::class,
+            'model' => 'Application',
+        ];
+
+        $result = $this->policyGenerator->callGeneratePolicyPath($entity);
+
+        expect($result)->toBe(
+            $policyPath . DIRECTORY_SEPARATOR . 'Applications' . DIRECTORY_SEPARATOR . 'ApplicationPolicy.php'
+        );
+    });
+
+    it('generates correct policy path for a flat model with the default policy path', function () {
+        $policyPath = app_path('Policies');
+        config()->set('filament-shield.policies.path', $policyPath);
+
+        $reflection = new ReflectionClass(Utils::class);
+        $prop = $reflection->getProperty('psr4Cache');
+        $prop->setValue(null, null);
+
+        $entity = [
+            'modelFqcn' => User::class,
+            'model' => 'User',
+        ];
+
+        $result = $this->policyGenerator->callGeneratePolicyPath($entity);
+
+        expect($result)->toBe($policyPath . DIRECTORY_SEPARATOR . 'UserPolicy.php');
+    });
+});
+
+describe('generatePolicyStubVariables namespace', function () {
+    it('generates correct namespace for a flat model with a non-default policy path', function () {
+        $policyPath = app_path('Filament' . DIRECTORY_SEPARATOR . 'Policies');
+        config()->set('filament-shield.policies.path', $policyPath);
+
+        $reflection = new ReflectionClass(Utils::class);
+        $prop = $reflection->getProperty('psr4Cache');
+        $prop->setValue(null, null);
+
+        FilamentShield::shouldReceive('getResourcePolicyActionsWithPermissions')
+            ->once()
+            ->andReturn([]);
+
+        $entity = [
+            'modelFqcn' => User::class,
+            'model' => 'User',
+            'resourceFqcn' => 'DummyResource',
+        ];
+
+        $result = $this->policyGenerator->callGeneratePolicyStubVariables($entity);
+
+        $expectedNamespace = Utils::resolveNamespaceFromPath($policyPath);
+        expect($result['namespace'])->toBe($expectedNamespace);
+    });
+
+    it('generates correct namespace for a nested model with a non-default policy path', function () {
+        $policyPath = app_path('Filament' . DIRECTORY_SEPARATOR . 'Policies');
+        config()->set('filament-shield.policies.path', $policyPath);
+
+        $reflection = new ReflectionClass(Utils::class);
+        $prop = $reflection->getProperty('psr4Cache');
+        $prop->setValue(null, null);
+
+        FilamentShield::shouldReceive('getResourcePolicyActionsWithPermissions')
+            ->once()
+            ->andReturn([]);
+
+        $entity = [
+            'modelFqcn' => Application::class,
+            'model' => 'Application',
+            'resourceFqcn' => 'DummyResource',
+        ];
+
+        $result = $this->policyGenerator->callGeneratePolicyStubVariables($entity);
+
+        $expectedNamespace = Utils::resolveNamespaceFromPath($policyPath) . '\\Applications';
+        expect($result['namespace'])->toBe($expectedNamespace);
+    });
+});

--- a/tests/Fixtures/Models/Applications/Application.php
+++ b/tests/Fixtures/Models/Applications/Application.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BezhanSalleh\FilamentShield\Tests\Fixtures\Models\Applications;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Application extends Model
+{
+    protected $guarded = [];
+}


### PR DESCRIPTION
Hi 👋

I recently upgraded from v3.3 to v4.2 and ran into an issue, which this PR fixes.

When policies.path is set to a nested directory like `app/Filament/Policies`, the generated policy path and namespace were incorrect. The old code used `afterLast('\\')` on the resolved namespace, stripping all but the last segment, then did a naive string replace of 'Models' in the model's path. This produced `app/Policies/UserPolicy.php` instead of the expected `app/Filament/Policies/UserPolicy.php`.

This change builds the policy path and namespace from `Utils::getPolicyPath()` directly, matching the approach already used for vendor models.

## Example

With `config('filament-shield.policies.path')` set to `app_path('Filament/Policies')`:

| Model | Before (broken) | After (fixed) |
|---|---|---|
| `app/Models/User.php` | `app/Policies/UserPolicy.php` | `app/Filament/Policies/UserPolicy.php` |
| `app/Models/Applications/Application.php` | `app/Policies/Applications/ApplicationPolicy.php` | `app/Filament/Policies/Applications/ApplicationPolicy.php` |

Same issue applied to the generated namespace (`App\Policies\...` instead of `App\Filament\Policies\...`).

## Tests

- [x] Added tests for flat model (`User`) with non-default policy path
- [x] Added tests for nested model (`Models/Applications/Application`) with non-default policy path
- [x] Added tests for flat model with default policy path
- [x] Added namespace generation tests for both flat and nested models
- [x] Existing test suite passes