### PR TITLE
feat: add configurable central_path_segments for policy generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `filament-shield` will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Configurable `policies.central_path_segments` for `shield:generate` to control when policies are written to `policies.path` vs co-located beside models
+
 ## 4.2.0 - 2026-03-22
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The easiest and most intuitive way to add access management to your Filament pan
     - [Methods](#methods)
     - [Merge](#merge)
     - [Single Parameter Methods](#single-parameter-methods)
+    - [Central Path Segments](#central-path-segments)
     - [Policy Enforcement](#policy-enforcement)
   - [Resources](#resources)
     - [Configuration](#configuration-2)
@@ -248,6 +249,10 @@ Shield automatically generates policies for your Resources' Models.
     'path' => app_path('Policies'),
     'merge' => true,
     'generate' => true,
+    'central_path_segments' => [
+        'vendor',
+        'src',
+    ],
     'methods' => [
         'viewAny', 'view', 'create', 'update', 'delete', 'deleteAny', 'restore',
         'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',
@@ -272,6 +277,28 @@ When `policies.merge` is set to `true`, Shield will combine the global methods d
 
 ### Single Parameter Methods
 Some policy methods only require the user instance as a parameter (e.g., `viewAny`, `create`). These are defined in `policies.single_parameter_methods`. Shield will generate these methods accordingly in the policies. When you add new methods or resource-specific methods, ensure to update this list if they also only require the user instance. This helps maintain consistency and clarity in your policy definitions.
+
+### Central Path Segments
+When running `shield:generate`, Shield decides where to write each policy file based on the model's filesystem path:
+
+- **Central path** (`policies.path`, e.g. `app/Policies`) — used when the model file path contains any segment listed in `policies.central_path_segments`.
+- **Co-located path** — used otherwise. Shield replaces `Models` with `Policies` in the model's namespace/path (e.g. `App\Models\Post` → `app/Policies/PostPolicy.php` or `Modules\Users\Models\Admin` → `Modules\Users\Policies\AdminPolicy.php`).
+
+The default segments are `vendor` and `src`, matching the previous hard-coded behavior for package and PSR-4 `src` trees.
+
+**Modular / monorepo apps:** models under paths such as `modules/Users/src/Models` also match the `src` segment, so policies may land in `app/Policies` instead of beside the module. Limit the list to only `vendor` if you want module policies co-located with their models:
+
+```php
+'central_path_segments' => [
+    'vendor',
+],
+```
+
+Set an empty array to always use co-located policies:
+
+```php
+'central_path_segments' => [],
+```
 
 ### Policy Enforcement
 Laravel automatically resolves policies for models, but this is not always the case. For instance, if your models are not in the default `App\Models` namespace, are nested, or are from third-party plugins, you may need to manually register the policies. You can do this in a service provider's `boot()` method: 

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -125,6 +125,25 @@ return [
         'path' => app_path('Policies'),
         'merge' => true,
         'generate' => true,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Central Policy Path Segments
+        |--------------------------------------------------------------------------
+        |
+        | When a model's file path contains any of these segments, the generated
+        | policy will be placed in policies.path. Otherwise, the policy is
+        | created alongside the model by replacing Models with Policies.
+        |
+        | For modular apps, you may prefer only ['vendor'] so that models under
+        | modules/{Module}/src are co-located with their policies.
+        |
+        */
+        'central_path_segments' => [
+            'vendor',
+            'src',
+        ],
+
         'methods' => [
             'viewAny', 'view', 'create', 'update', 'delete', 'deleteAny', 'restore',
             'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',

--- a/src/Commands/Concerns/CanGeneratePolicy.php
+++ b/src/Commands/Concerns/CanGeneratePolicy.php
@@ -28,7 +28,7 @@ trait CanGeneratePolicy
     {
         $path = (new ReflectionClass($entity['modelFqcn']))->getFileName();
 
-        if (Str::of($path)->contains(['vendor', 'src'])) {
+        if (Utils::shouldUseCentralPolicyPath($path)) {
             return Str::of($entity['model'])
                 ->prepend(str(Utils::getPolicyPath())->append('\\'))
                 ->replace('\\', DIRECTORY_SEPARATOR)
@@ -67,7 +67,7 @@ trait CanGeneratePolicy
 
         $policyNamespace = Str::of(Utils::resolveNamespaceFromPath(Utils::getPolicyPath()))->afterLast('\\')->toString();
 
-        $stubVariables['namespace'] = Str::of($path)->contains(['vendor', 'src'])
+        $stubVariables['namespace'] = Utils::shouldUseCentralPolicyPath($path)
             ? Utils::resolveNamespaceFromPath(Utils::getPolicyPath())
             : Str::of($namespace)->replace('Models', $policyNamespace)->toString(); /** @phpstan-ignore-line */
         $stubVariables['model_name'] = $entity['model'];

--- a/src/Support/Utils.php
+++ b/src/Support/Utils.php
@@ -128,6 +128,31 @@ class Utils
             ->toString();
     }
 
+    /**
+     * @return list<string>
+     */
+    public static function getCentralPolicyPathSegments(): array
+    {
+        $segments = static::getConfig()->policies->central_path_segments ?? ['vendor', 'src'];
+
+        if (! is_array($segments)) {
+            return ['vendor', 'src'];
+        }
+
+        return array_values($segments);
+    }
+
+    public static function shouldUseCentralPolicyPath(string $modelFilePath): bool
+    {
+        $segments = static::getCentralPolicyPathSegments();
+
+        if ($segments === []) {
+            return false;
+        }
+
+        return Str::of($modelFilePath)->contains($segments);
+    }
+
     public static function getRolePolicyPath(): ?string
     {
         $filesystem = new Filesystem;

--- a/tests/Unit/Utils/CentralPolicyPathSegmentsTest.php
+++ b/tests/Unit/Utils/CentralPolicyPathSegmentsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use BezhanSalleh\FilamentShield\Support\Utils;
+
+it('defaults central policy path segments to vendor and src', function (): void {
+    config()->set('filament-shield.policies.central_path_segments', null);
+
+    expect(Utils::getCentralPolicyPathSegments())->toBe(['vendor', 'src']);
+});
+
+it('reads central policy path segments from config', function (): void {
+    config()->set('filament-shield.policies.central_path_segments', ['vendor', 'packages']);
+
+    expect(Utils::getCentralPolicyPathSegments())->toBe(['vendor', 'packages']);
+});
+
+it('uses central policy path when model path matches a segment', function (): void {
+    config()->set('filament-shield.policies.central_path_segments', ['vendor', 'src']);
+
+    expect(Utils::shouldUseCentralPolicyPath('/app/vendor/acme/models/User.php'))->toBeTrue()
+        ->and(Utils::shouldUseCentralPolicyPath('/app/modules/Users/src/Models/Admin.php'))->toBeTrue();
+});
+
+it('uses co-located policy path when no segment matches', function (): void {
+    config()->set('filament-shield.policies.central_path_segments', ['vendor']);
+
+    expect(Utils::shouldUseCentralPolicyPath('/app/modules/Users/src/Models/Admin.php'))->toBeFalse()
+        ->and(Utils::shouldUseCentralPolicyPath('/app/app/Models/Post.php'))->toBeFalse();
+});
+
+it('never uses central policy path when segments are empty', function (): void {
+    config()->set('filament-shield.policies.central_path_segments', []);
+
+    expect(Utils::shouldUseCentralPolicyPath('/app/vendor/acme/models/User.php'))->toBeFalse();
+});


### PR DESCRIPTION
Add policies.central_path_segments so apps can control when policies are
written to policies.path versus co-located beside models. Defaults to
vendor and src to preserve existing behavior.
- Add Utils::getCentralPolicyPathSegments() and shouldUseCentralPolicyPath()
- Replace hard-coded path checks in CanGeneratePolicy
- Document in README and CHANGELOG
- Add unit tests for segment resolution